### PR TITLE
KE-37: 거래목록 조회 삭제 여부 조건 추가

### DIFF
--- a/src/main/java/com/kh/bookfinder/repository/BookTradeRepository.java
+++ b/src/main/java/com/kh/bookfinder/repository/BookTradeRepository.java
@@ -1,6 +1,7 @@
 package com.kh.bookfinder.repository;
 
 import com.kh.bookfinder.entity.BookTrade;
+import com.kh.bookfinder.entity.Status;
 import java.util.ArrayList;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -8,5 +9,5 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface BookTradeRepository extends JpaRepository<BookTrade, Long> {
 
-  ArrayList<BookTrade> findByBoroughId(Long boroughId);
+  ArrayList<BookTrade> findByBoroughIdAndDeleteYn(Long boroughId, Status deleteYn);
 }

--- a/src/main/java/com/kh/bookfinder/service/BookTradeService.java
+++ b/src/main/java/com/kh/bookfinder/service/BookTradeService.java
@@ -1,6 +1,7 @@
 package com.kh.bookfinder.service;
 
 import com.kh.bookfinder.entity.BookTrade;
+import com.kh.bookfinder.entity.Status;
 import com.kh.bookfinder.repository.BookTradeRepository;
 import java.util.ArrayList;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,7 +15,7 @@ public class BookTradeService {
   BookTradeRepository bookTradeRepository;
 
   public ArrayList<BookTrade> getBookTrades(Long boroughId) {
-    return bookTradeRepository.findByBoroughId(boroughId);
+    return bookTradeRepository.findByBoroughIdAndDeleteYn(boroughId, Status.N);
   }
 
   @Transactional


### PR DESCRIPTION
# KE-37: 거래목록 조회 삭제 여부 조건 추가
- 현재 지역 번호를 받으면 해당하는 목록을 전부 반환해주고 있었는데 deleteYn조건을 추가해 삭제 되지 않은 글들만 반환하도록 수정했습니다