### PR TITLE
JH-57: 이메일 인증코드 보내기 API 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ build/
 ## properties
 application-db.properties
 application-test*.properties
+application-mail.yml
 
 
 ### STS ###

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.security:spring-security-crypto'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'

--- a/src/main/java/com/kh/bookfinder/config/EmailConfig.java
+++ b/src/main/java/com/kh/bookfinder/config/EmailConfig.java
@@ -1,0 +1,58 @@
+package com.kh.bookfinder.config;
+
+import java.util.Properties;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.mail.javamail.JavaMailSenderImpl;
+
+@Configuration
+public class EmailConfig {
+
+  @Value("${spring.mail.host}")
+  private String host;
+  @Value(("${spring.mail.port}"))
+  private int port;
+  @Value(("${spring.mail.username}"))
+  private String username;
+  @Value(("${spring.mail.password}"))
+  private String password;
+  @Value(("${spring.mail.properties.mail.smtp.auth}"))
+  private boolean auth;
+  @Value(("${spring.mail.properties.mail.smtp.starttls.enable}"))
+  private boolean starttlsEnable;
+  @Value(("${spring.mail.properties.mail.smtp.starttls.required}"))
+  private boolean starttlsRequired;
+  @Value(("${spring.mail.properties.mail.smtp.connectiontimeout}"))
+  private int connectionTimeout;
+  @Value(("${spring.mail.properties.mail.smtp.timeout}"))
+  private int timeout;
+  @Value(("${spring.mail.properties.mail.smtp.writetimeout}"))
+  private int writeTimeout;
+
+  @Bean
+  public JavaMailSender javaMailSender() {
+    JavaMailSenderImpl mailSender = new JavaMailSenderImpl();
+    mailSender.setHost(host);
+    mailSender.setPort(port);
+    mailSender.setUsername(username);
+    mailSender.setPassword(password);
+    mailSender.setDefaultEncoding("UTF-8");
+    mailSender.setJavaMailProperties(getMailProperties());
+
+    return mailSender;
+  }
+
+  private Properties getMailProperties() {
+    Properties properties = new Properties();
+    properties.put("mail.smtp.auth", auth);
+    properties.put("mail.smtp.starttls.enable", starttlsEnable);
+    properties.put("mail.smtp.starttls.required", starttlsRequired);
+    properties.put("mail.smtp.starttls.connectiontimeout", connectionTimeout);
+    properties.put("mail.smtp.starttls.timeout", timeout);
+    properties.put("mail.smtp.starttls.writetimeout", writeTimeout);
+    return properties;
+  }
+
+}

--- a/src/main/java/com/kh/bookfinder/constants/Message.java
+++ b/src/main/java/com/kh/bookfinder/constants/Message.java
@@ -8,8 +8,11 @@ public interface Message {
       로그인 후 이용해 주세요 😊
       """;
   String BAD_REQUEST = "요청이 유효하지 않습니다. 다시 한번 확인해주세요.";
+
   String VALID_EMAIL = "가입이 가능한 이메일입니다.";
   String INVALID_EMAIL = "유효하지 않은 이메일 형식입니다.";
+  String DUPLICATE_EMAIL = "이미 가입된 이메일입니다.";
+  String INVALID_FIELD = "field는 email만 가능합니다.";
   String INVALID_PASSWORD = "영문, 숫자, 특수기호를 포함하여 8자 이상 20자 이하로 입력해주세요.";
   String INVALID_PASSWORD_CONFIRM = "비밀번호와 비밀번호 확인이 일치하지 않습니다.";
   String INVALID_NICKNAME = "영문, 유효한 한글, 숫자를 이용하여 3자 이상 10자 이하로 입력해주세요.";

--- a/src/main/java/com/kh/bookfinder/constants/Message.java
+++ b/src/main/java/com/kh/bookfinder/constants/Message.java
@@ -8,6 +8,7 @@ public interface Message {
       로그인 후 이용해 주세요 😊
       """;
   String BAD_REQUEST = "요청이 유효하지 않습니다. 다시 한번 확인해주세요.";
+  String VALID_EMAIL = "가입이 가능한 이메일입니다.";
   String INVALID_EMAIL = "유효하지 않은 이메일 형식입니다.";
   String INVALID_PASSWORD = "영문, 숫자, 특수기호를 포함하여 8자 이상 20자 이하로 입력해주세요.";
   String INVALID_PASSWORD_CONFIRM = "비밀번호와 비밀번호 확인이 일치하지 않습니다.";

--- a/src/main/java/com/kh/bookfinder/constants/Message.java
+++ b/src/main/java/com/kh/bookfinder/constants/Message.java
@@ -12,10 +12,12 @@ public interface Message {
   String VALID_EMAIL = "가입이 가능한 이메일입니다.";
   String INVALID_EMAIL = "유효하지 않은 이메일 형식입니다.";
   String DUPLICATE_EMAIL = "이미 가입된 이메일입니다.";
-  String INVALID_FIELD = "field는 email만 가능합니다.";
+  String INVALID_FIELD = "field는 email이나 nickname만 가능합니다.";
   String INVALID_PASSWORD = "영문, 숫자, 특수기호를 포함하여 8자 이상 20자 이하로 입력해주세요.";
   String INVALID_PASSWORD_CONFIRM = "비밀번호와 비밀번호 확인이 일치하지 않습니다.";
   String INVALID_NICKNAME = "영문, 유효한 한글, 숫자를 이용하여 3자 이상 10자 이하로 입력해주세요.";
+  String VALID_NICKNAME = "가입이 가능한 닉네임입니다.";
+  String DUPLICATE_NICKNAME = "이미 가입된 닉네임입니다.";
   String INVALID_PHONE = "유효하지 않은 휴대폰 번호 형식입니다.";
 
   String INVALID_ISBN_DIGITS = "ISBN 번호는 13자리의 숫자만 입력 가능합니다.";
@@ -27,4 +29,8 @@ public interface Message {
   String DELETED_TRADE = "삭제된 게시물 입니다.";
   String SUCCESS_UPDATE = "게시글을 성공적으로 수정했습니다.";
   String SUCCESS_DELETE = "게시글을 성공적으로 삭제했습니다.";
+
+  static String getSuccessMessageBy(String field) {
+    return field.equals("email") ? VALID_EMAIL : VALID_NICKNAME;
+  }
 }

--- a/src/main/java/com/kh/bookfinder/controller/UserController.java
+++ b/src/main/java/com/kh/bookfinder/controller/UserController.java
@@ -38,7 +38,7 @@ public class UserController {
   @GetMapping(value = "/signup/duplicate", produces = "application/json;charset=UTF-8")
   public ResponseEntity<String> checkDuplicate(@Valid DuplicateCheckDto duplicateCheckDto)
       throws JSONException {
-    userService.findBy(duplicateCheckDto);
+    userService.checkDuplicate(duplicateCheckDto);
     JSONObject responseBody = new JSONObject();
 
     responseBody.put("message", Message.VALID_EMAIL);

--- a/src/main/java/com/kh/bookfinder/controller/UserController.java
+++ b/src/main/java/com/kh/bookfinder/controller/UserController.java
@@ -41,7 +41,7 @@ public class UserController {
     userService.checkDuplicate(duplicateCheckDto);
     JSONObject responseBody = new JSONObject();
 
-    responseBody.put("message", Message.VALID_EMAIL);
+    responseBody.put("message", Message.getSuccessMessageBy(duplicateCheckDto.getField()));
     return ResponseEntity
         .ok()
         .body(responseBody.toString());

--- a/src/main/java/com/kh/bookfinder/controller/UserController.java
+++ b/src/main/java/com/kh/bookfinder/controller/UserController.java
@@ -2,7 +2,10 @@ package com.kh.bookfinder.controller;
 
 import com.kh.bookfinder.constants.Message;
 import com.kh.bookfinder.dto.DuplicateCheckDto;
+import com.kh.bookfinder.dto.SendingEmailAuthDto;
 import com.kh.bookfinder.dto.SignUpDto;
+import com.kh.bookfinder.entity.EmailAuth;
+import com.kh.bookfinder.service.EmailAuthService;
 import com.kh.bookfinder.service.UserService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -18,12 +21,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1")
+@RequestMapping("/api/v1/signup")
 public class UserController {
 
   private final UserService userService;
+  private final EmailAuthService emailAuthService;
 
-  @PostMapping(value = "/signup", produces = "application/json;charset=UTF-8")
+  @PostMapping(value = "/", produces = "application/json;charset=UTF-8")
   public ResponseEntity<String> signUp(@RequestBody @Valid SignUpDto signUpDto)
       throws JSONException {
     userService.save(signUpDto);
@@ -35,13 +39,27 @@ public class UserController {
         .body(responseBody.toString());
   }
 
-  @GetMapping(value = "/signup/duplicate", produces = "application/json;charset=UTF-8")
+  @GetMapping(value = "/duplicate", produces = "application/json;charset=UTF-8")
   public ResponseEntity<String> checkDuplicate(@Valid DuplicateCheckDto duplicateCheckDto)
       throws JSONException {
     userService.checkDuplicate(duplicateCheckDto);
     JSONObject responseBody = new JSONObject();
 
     responseBody.put("message", Message.getSuccessMessageBy(duplicateCheckDto.getField()));
+    return ResponseEntity
+        .ok()
+        .body(responseBody.toString());
+  }
+
+  @PostMapping(value = "/email", produces = "application/json;charset=UTF-8")
+  public ResponseEntity<String> sendAuthEmail(@Valid @RequestBody SendingEmailAuthDto requestBody)
+      throws JSONException {
+    EmailAuth emailAuth = this.emailAuthService.sendAuthCodeTo(requestBody.getEmail());
+    String signingToken = emailAuth.generateSigningToken();
+
+    JSONObject responseBody = new JSONObject();
+    responseBody.put("signingToken", signingToken);
+
     return ResponseEntity
         .ok()
         .body(responseBody.toString());

--- a/src/main/java/com/kh/bookfinder/controller/UserController.java
+++ b/src/main/java/com/kh/bookfinder/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.kh.bookfinder.controller;
 
 import com.kh.bookfinder.constants.Message;
+import com.kh.bookfinder.dto.DuplicateCheckDto;
 import com.kh.bookfinder.dto.SignUpDto;
 import com.kh.bookfinder.service.UserService;
 import jakarta.validation.Valid;
@@ -9,17 +10,20 @@ import org.springframework.boot.configurationprocessor.json.JSONException;
 import org.springframework.boot.configurationprocessor.json.JSONObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
+@RequestMapping("/api/v1")
 public class UserController {
 
   private final UserService userService;
 
-  @PostMapping(value = "/api/v1/signup", produces = "application/json;charset=UTF-8")
+  @PostMapping(value = "/signup", produces = "application/json;charset=UTF-8")
   public ResponseEntity<String> signUp(@RequestBody @Valid SignUpDto signUpDto)
       throws JSONException {
     userService.save(signUpDto);
@@ -31,4 +35,15 @@ public class UserController {
         .body(responseBody.toString());
   }
 
+  @GetMapping(value = "/signup/duplicate", produces = "application/json;charset=UTF-8")
+  public ResponseEntity<String> checkDuplicate(@Valid DuplicateCheckDto duplicateCheckDto)
+      throws JSONException {
+    userService.findBy(duplicateCheckDto);
+    JSONObject responseBody = new JSONObject();
+
+    responseBody.put("message", Message.VALID_EMAIL);
+    return ResponseEntity
+        .ok()
+        .body(responseBody.toString());
+  }
 }

--- a/src/main/java/com/kh/bookfinder/dto/DuplicateCheckDto.java
+++ b/src/main/java/com/kh/bookfinder/dto/DuplicateCheckDto.java
@@ -1,0 +1,16 @@
+package com.kh.bookfinder.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class DuplicateCheckDto {
+
+  private String field;
+  private String value;
+}

--- a/src/main/java/com/kh/bookfinder/dto/DuplicateCheckDto.java
+++ b/src/main/java/com/kh/bookfinder/dto/DuplicateCheckDto.java
@@ -1,5 +1,9 @@
 package com.kh.bookfinder.dto;
 
+import com.kh.bookfinder.constants.Message;
+import com.kh.bookfinder.constants.Regexp;
+import com.kh.bookfinder.exception.InvalidFieldException;
+import jakarta.validation.constraints.AssertTrue;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -13,4 +17,20 @@ public class DuplicateCheckDto {
 
   private String field;
   private String value;
+
+  @AssertTrue
+  public boolean isValid() {
+    if (!field.equals("email")) {
+      throw new InvalidFieldException("field", Message.INVALID_FIELD);
+    }
+    if (!isValidEmail()) {
+      throw new InvalidFieldException("email", Message.INVALID_EMAIL);
+    }
+
+    return true;
+  }
+
+  public boolean isValidEmail() {
+    return this.value.matches(Regexp.EMAIL);
+  }
 }

--- a/src/main/java/com/kh/bookfinder/dto/DuplicateCheckDto.java
+++ b/src/main/java/com/kh/bookfinder/dto/DuplicateCheckDto.java
@@ -4,6 +4,7 @@ import com.kh.bookfinder.constants.Message;
 import com.kh.bookfinder.constants.Regexp;
 import com.kh.bookfinder.exception.InvalidFieldException;
 import jakarta.validation.constraints.AssertTrue;
+import java.util.Arrays;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -20,11 +21,14 @@ public class DuplicateCheckDto {
 
   @AssertTrue
   public boolean isValid() {
-    if (!field.equals("email")) {
+    if (!Arrays.asList("nickname", "email").contains(field)) {
       throw new InvalidFieldException("field", Message.INVALID_FIELD);
     }
-    if (!isValidEmail()) {
+    if (field.equals("email") && !isValidEmail()) {
       throw new InvalidFieldException("email", Message.INVALID_EMAIL);
+    }
+    if (field.equals("nickname") && !isValidNickname()) {
+      throw new InvalidFieldException("nickname", Message.INVALID_NICKNAME);
     }
 
     return true;
@@ -32,5 +36,9 @@ public class DuplicateCheckDto {
 
   public boolean isValidEmail() {
     return this.value.matches(Regexp.EMAIL);
+  }
+
+  public boolean isValidNickname() {
+    return this.value.matches(Regexp.NICKNAME);
   }
 }

--- a/src/main/java/com/kh/bookfinder/dto/SendingEmailAuthDto.java
+++ b/src/main/java/com/kh/bookfinder/dto/SendingEmailAuthDto.java
@@ -1,0 +1,19 @@
+package com.kh.bookfinder.dto;
+
+import com.kh.bookfinder.constants.Message;
+import com.kh.bookfinder.constants.Regexp;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class SendingEmailAuthDto {
+
+  @Pattern(regexp = Regexp.EMAIL, message = Message.INVALID_EMAIL)
+  private String email;
+}

--- a/src/main/java/com/kh/bookfinder/entity/EmailAuth.java
+++ b/src/main/java/com/kh/bookfinder/entity/EmailAuth.java
@@ -1,0 +1,61 @@
+package com.kh.bookfinder.entity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.Random;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Builder.Default;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.springframework.boot.configurationprocessor.json.JSONException;
+import org.springframework.boot.configurationprocessor.json.JSONObject;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "email_auth",
+    uniqueConstraints = @UniqueConstraint(columnNames = {"auth_code", "email"}))
+public class EmailAuth implements Serializable {
+
+  private final static String ALPHABET_AND_NUMBER = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+  private final static int AUTH_CODE_MAX_LENGTH = 8;
+  private final static int DEFAULT_EXPIRATION_MINUTES = 5;
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+  @Default
+  private String authCode = generateAuthCode();
+  private String email;
+  @Default
+  private LocalDateTime expiration = LocalDateTime.now().plusMinutes(DEFAULT_EXPIRATION_MINUTES);
+
+  private static String generateAuthCode() {
+    Random random = new Random();
+    StringBuilder result = new StringBuilder();
+    for (int i = 0; i < AUTH_CODE_MAX_LENGTH; i++) {
+      int index = random.nextInt(ALPHABET_AND_NUMBER.length());
+      result.append(ALPHABET_AND_NUMBER.charAt(index));
+    }
+    return result.toString();
+  }
+
+  public String generateSigningToken() throws JSONException {
+    JSONObject jsonObject = new JSONObject();
+    jsonObject.put("email", email);
+    jsonObject.put("code", authCode);
+
+    return Base64.getEncoder().encodeToString(jsonObject.toString().getBytes(StandardCharsets.UTF_8));
+  }
+}

--- a/src/main/java/com/kh/bookfinder/entity/EmailAuth.java
+++ b/src/main/java/com/kh/bookfinder/entity/EmailAuth.java
@@ -34,7 +34,7 @@ public class EmailAuth implements Serializable {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long id;
+  private Long auth_id;
   @Default
   private String authCode = generateAuthCode();
   private String email;

--- a/src/main/java/com/kh/bookfinder/repository/EmailAuthRepository.java
+++ b/src/main/java/com/kh/bookfinder/repository/EmailAuthRepository.java
@@ -1,0 +1,8 @@
+package com.kh.bookfinder.repository;
+
+import com.kh.bookfinder.entity.EmailAuth;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface EmailAuthRepository extends JpaRepository<EmailAuth, Long> {
+
+}

--- a/src/main/java/com/kh/bookfinder/repository/UserRepository.java
+++ b/src/main/java/com/kh/bookfinder/repository/UserRepository.java
@@ -3,8 +3,12 @@ package com.kh.bookfinder.repository;
 import com.kh.bookfinder.entity.User;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
   Optional<User> findByEmail(String email);
+
+  Optional<User> findByNickname(String nickname);
 }

--- a/src/main/java/com/kh/bookfinder/service/EmailAuthService.java
+++ b/src/main/java/com/kh/bookfinder/service/EmailAuthService.java
@@ -1,0 +1,35 @@
+package com.kh.bookfinder.service;
+
+import com.kh.bookfinder.entity.EmailAuth;
+import com.kh.bookfinder.repository.EmailAuthRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class EmailAuthService {
+
+  private final static String MAIL_SUBJECT = "북적북적에서 보내는 이메일 인증 코드입니다.";
+  private final JavaMailSender emailSender;
+  private final EmailAuthRepository emailAuthRepository;
+
+  public EmailAuth sendAuthCodeTo(String targetEmail) {
+    EmailAuth emailAuth = EmailAuth
+        .builder()
+        .email(targetEmail)
+        .build();
+    emailAuthRepository.save(emailAuth);
+
+    SimpleMailMessage emailForm = new SimpleMailMessage();
+    emailForm.setTo(targetEmail);
+    emailForm.setSubject(MAIL_SUBJECT);
+    emailForm.setText(emailAuth.getAuthCode());
+    emailSender.send(emailForm);
+
+    return emailAuth;
+  }
+}

--- a/src/main/java/com/kh/bookfinder/service/UserService.java
+++ b/src/main/java/com/kh/bookfinder/service/UserService.java
@@ -1,6 +1,7 @@
 package com.kh.bookfinder.service;
 
 import com.kh.bookfinder.constants.Message;
+import com.kh.bookfinder.dto.DuplicateCheckDto;
 import com.kh.bookfinder.dto.SignUpDto;
 import com.kh.bookfinder.entity.User;
 import com.kh.bookfinder.exception.InvalidFieldException;
@@ -22,5 +23,9 @@ public class UserService {
     }
     User user = signUpDto.toEntity(passwordEncoder);
     this.userRepository.save(user);
+  }
+
+  public User findBy(DuplicateCheckDto duplicateCheckDto) {
+    return this.userRepository.findByEmail(duplicateCheckDto.getValue()).orElse(null);
   }
 }

--- a/src/main/java/com/kh/bookfinder/service/UserService.java
+++ b/src/main/java/com/kh/bookfinder/service/UserService.java
@@ -25,7 +25,10 @@ public class UserService {
     this.userRepository.save(user);
   }
 
-  public User findBy(DuplicateCheckDto duplicateCheckDto) {
-    return this.userRepository.findByEmail(duplicateCheckDto.getValue()).orElse(null);
+  public void checkDuplicate(DuplicateCheckDto duplicateCheckDto) {
+    this.userRepository.findByEmail(duplicateCheckDto.getValue())
+        .ifPresent((value) -> {
+          throw new InvalidFieldException("email", Message.DUPLICATE_EMAIL);
+        });
   }
 }

--- a/src/main/java/com/kh/bookfinder/service/UserService.java
+++ b/src/main/java/com/kh/bookfinder/service/UserService.java
@@ -21,14 +21,34 @@ public class UserService {
     if (!signUpDto.equalsPassword()) {
       throw new InvalidFieldException("password", Message.INVALID_PASSWORD_CONFIRM);
     }
+    this.userRepository
+        .findByEmail(signUpDto.getEmail())
+        .ifPresent((value) -> {
+          throw new InvalidFieldException("email", Message.DUPLICATE_EMAIL);
+        });
+    this.userRepository
+        .findByNickname(signUpDto.getNickname())
+        .ifPresent((value) -> {
+          throw new InvalidFieldException("nickname", Message.DUPLICATE_NICKNAME);
+        });
+
     User user = signUpDto.toEntity(passwordEncoder);
     this.userRepository.save(user);
   }
 
   public void checkDuplicate(DuplicateCheckDto duplicateCheckDto) {
-    this.userRepository.findByEmail(duplicateCheckDto.getValue())
-        .ifPresent((value) -> {
-          throw new InvalidFieldException("email", Message.DUPLICATE_EMAIL);
-        });
+    if (duplicateCheckDto.getField().equals("email")) {
+      this.userRepository.findByEmail(duplicateCheckDto.getValue())
+          .ifPresent((value) -> {
+            throw new InvalidFieldException("email", Message.DUPLICATE_EMAIL);
+          });
+    }
+    if (duplicateCheckDto.getField().equals("nickname")) {
+      this.userRepository.findByNickname(duplicateCheckDto.getValue())
+          .ifPresent((value) -> {
+            throw new InvalidFieldException("nickname", Message.DUPLICATE_NICKNAME);
+          });
+    }
+
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 spring.application.name=BookFinder
-spring.profiles.include=db
+spring.config.import=classpath:application-db.properties, application-mail.yml

--- a/src/test/java/com/kh/bookfinder/controller/SendAuthEmailApiTest.java
+++ b/src/test/java/com/kh/bookfinder/controller/SendAuthEmailApiTest.java
@@ -1,0 +1,90 @@
+package com.kh.bookfinder.controller;
+
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kh.bookfinder.constants.Message;
+import com.kh.bookfinder.dto.SendingEmailAuthDto;
+import com.kh.bookfinder.entity.EmailAuth;
+import com.kh.bookfinder.service.EmailAuthService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class SendAuthEmailApiTest {
+
+  private static final String MOCK_SIGNING_TOKEN = "eyJlbWFpbCI6ImppbmhvNDc0NEBuYXZlci5jb20iLCJjb2RlIjoiZHdmOHlGclgifQ==";
+  @Autowired
+  private MockMvc mockMvc;
+  @Autowired
+  private ObjectMapper objectMapper;
+  @MockBean
+  private EmailAuthService emailAuthService;
+  private EmailAuth mockEmailAuth;
+
+  @BeforeEach
+  public void setup() {
+    mockEmailAuth = mock(EmailAuth.class);
+  }
+
+  @Test
+  @DisplayName("유효한 형식의 email이 주어지는 경우")
+  public void sendAuthEmailSuccessTest() throws Exception {
+    // Given: 유효한 형식의 SendingEmailAuthDto가 주어진다.
+    SendingEmailAuthDto requestDto = SendingEmailAuthDto
+        .builder()
+        .email("jinho4744@naver.com")
+        .build();
+    String requestBody = objectMapper.writeValueAsString(requestDto);
+    // And: EmailService의 sendAuthCodeTo()를 모킹한다.
+    when(emailAuthService.sendAuthCodeTo(any())).thenReturn(mockEmailAuth);
+    when(mockEmailAuth.generateSigningToken()).thenReturn(MOCK_SIGNING_TOKEN);
+
+    // When: Sending Auth Code Email API를 호출한다.
+    mockMvc.perform(MockMvcRequestBuilders
+        .post("/api/v1/signup/email")
+        .content(requestBody)
+        .contentType(MediaType.APPLICATION_JSON)
+    )
+        // Then: Status는 200 Ok이다.
+        .andExpect(MockMvcResultMatchers.status().isOk())
+        // And: Response Body로 signingToken을 반환한다.
+        .andExpect(MockMvcResultMatchers.jsonPath("$.signingToken", is(MOCK_SIGNING_TOKEN)));
+  }
+
+  @Test
+  @DisplayName("유효하지 않은 형식의 email이 주어지는 경우")
+  public void sendAuthEmailFailTest() throws Exception {
+    // Given: 유효하지 않은 형식의 SendingEmailAuthDto가 주어진다.
+    SendingEmailAuthDto requestDto = SendingEmailAuthDto
+        .builder()
+        .email("jinho4744navercom")
+        .build();
+    String requestBody = objectMapper.writeValueAsString(requestDto);
+
+    // When: Sending Auth Code Email API를 호출한다.
+    mockMvc.perform(MockMvcRequestBuilders
+        .post("/api/v1/signup/email")
+        .content(requestBody)
+        .contentType(MediaType.APPLICATION_JSON)
+    )
+        // Then: Status는 400 Bad Request이다.
+        .andExpect(MockMvcResultMatchers.status().isBadRequest())
+        // And: Response Body로 message와 details가 반환된다.
+        .andExpect(MockMvcResultMatchers.jsonPath("$.message", is(Message.BAD_REQUEST)))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.details.email", is(Message.INVALID_EMAIL)));
+  }
+}

--- a/src/test/java/com/kh/bookfinder/controller/SignUpApiTest.java
+++ b/src/test/java/com/kh/bookfinder/controller/SignUpApiTest.java
@@ -26,7 +26,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 @ActiveProfiles("test")
 @Transactional
-public class UserControllerTest {
+public class SignUpApiTest {
 
   /* TODO: 이메일 인증, 이메일 중복확인, 닉네임 중복확인 API 추가되면 Signup 테스트도 수정되어야 함
            주소에 대한 유효성 검사 생각해 봐야함

--- a/src/test/java/com/kh/bookfinder/controller/SignUpApiTest.java
+++ b/src/test/java/com/kh/bookfinder/controller/SignUpApiTest.java
@@ -17,6 +17,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -28,7 +29,7 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 @Transactional
 public class SignUpApiTest {
 
-  /* TODO: 이메일 인증, 이메일 중복확인, 닉네임 중복확인 API 추가되면 Signup 테스트도 수정되어야 함
+  /* TODO: 이메일 인증 API 추가되면 Signup 테스트도 수정되어야 함
            주소에 대한 유효성 검사 생각해 봐야함
            데이터베이스를 모킹해야하는가?에 대해 생각해 봐야함
    */
@@ -89,8 +90,36 @@ public class SignUpApiTest {
   }
 
   @Test
-  @DisplayName("SignUpDto의 password가 유효하지 않은 경우")
+  @DisplayName("SignUpDto의 email이 이미 가입한 email인 경우")
+  @Sql("classpath:oneUserInsert.sql")
   public void signUpFailTest2() throws Exception {
+    // Given: email이 jinho@kh.kr인 User를 데이터베이스에 추가한다.
+    assertThat(userRepository.findByEmail("jinho@kh.kr").orElse(null)).isNotNull();
+    // Given: email이 jinho@kh.kr인 SignUpDto가 주어진다.
+    SignUpDto validUserSignUpDto = this.buildValidSignUpDto();
+    validUserSignUpDto.setEmail("jinho@kh.kr");
+    String requestBody = objectMapper.writeValueAsString(validUserSignUpDto);
+
+    // When: SignUp API를 호출한다.
+    this.mockMvc
+        .perform(MockMvcRequestBuilders
+            .post("/api/v1/signup")
+            .content(requestBody)
+            .contentType("application/json")
+        )
+        // Then: Status는 400 Bad Request 이다.
+        // And: message는 "요청이 유효하지 않습니다. 다시 한번 확인해 주세요."이다.
+        // And: details는 {"email": "이미 가입된 이메일입니다."}이다.
+        .andExpect(MockMvcResultMatchers.status().isBadRequest())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.message", is(Message.BAD_REQUEST)))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.details.email", is(Message.DUPLICATE_EMAIL)));
+    // And: 데이터베이스에 해당 User 정보가 저장되지 않는다.
+    assertThat(userRepository.findAll()).hasSize(1);
+  }
+
+  @Test
+  @DisplayName("SignUpDto의 password가 유효하지 않은 경우")
+  public void signUpFailTest3() throws Exception {
     // Given: 유효하지 않은 SignUpDto가 주어진다. (password)
     SignUpDto invalidUserSignUpDto = this.buildValidSignUpDto();
     invalidUserSignUpDto.setPassword("1234");
@@ -115,7 +144,7 @@ public class SignUpApiTest {
 
   @Test
   @DisplayName("SignUpDto의 password와 passwordConfirm이 일치하지 않는 경우")
-  public void signUpFailTest3() throws Exception {
+  public void signUpFailTest4() throws Exception {
     // Given: 유효하지 않은 SignUpDto가 주어진다. (password)
     SignUpDto invalidUserSignUpDto = this.buildValidSignUpDto();
     invalidUserSignUpDto.setPasswordConfirm("q1w2e3r42@");
@@ -140,7 +169,7 @@ public class SignUpApiTest {
 
   @Test
   @DisplayName("SignUpDto의 nickname이 유효하지 않은 경우")
-  public void signUpFailTest4() throws Exception {
+  public void signUpFailTest5() throws Exception {
     // Given: 유효하지 않은 SignUpDto가 주어진다. (nickname)
     SignUpDto invalidUserSignUpDto = this.buildValidSignUpDto();
     invalidUserSignUpDto.setNickname("ㅂㅈㄷㄱ");
@@ -164,8 +193,37 @@ public class SignUpApiTest {
   }
 
   @Test
+  @DisplayName("SignUpDto의 nickname이 이미 가입한 nickname인 경우")
+  @Sql("classpath:oneUserInsert.sql")
+  public void signUpFailTest6() throws Exception {
+    // Given: nickname이 nickname인 User를 데이터베이스에 추가한다.
+    assertThat(userRepository.findByNickname("nickname").orElse(null)).isNotNull();
+    // And: nickname이 nickname인 SignUpDto가 주어진다.
+    SignUpDto validUserSignUpDto = this.buildValidSignUpDto();
+    validUserSignUpDto.setNickname("nickname");
+    validUserSignUpDto.setEmail("jinho2@kh.kr");
+    String requestBody = objectMapper.writeValueAsString(validUserSignUpDto);
+
+    // When: SignUp API를 호출한다.
+    this.mockMvc
+        .perform(MockMvcRequestBuilders
+            .post("/api/v1/signup")
+            .content(requestBody)
+            .contentType("application/json")
+        )
+        // Then: Status는 400 Bad Request 이다.
+        // And: message는 "요청이 유효하지 않습니다. 다시 한번 확인해 주세요."이다.
+        // And: details는 {"nickname": "이미 가입된 닉네임입니다."}이다.
+        .andExpect(MockMvcResultMatchers.status().isBadRequest())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.message", is(Message.BAD_REQUEST)))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.details.nickname", is(Message.DUPLICATE_NICKNAME)));
+    // And: 데이터베이스에 해당 User 정보가 저장되지 않는다.
+    assertThat(userRepository.findAll()).hasSize(1);
+  }
+
+  @Test
   @DisplayName("SignUpDto의 phone이 유효하지 않은 경우")
-  public void signUpFailTest5() throws Exception {
+  public void signUpFailTest7() throws Exception {
     // Given: 유효하지 않은 SignUpDto가 주어진다. (phone)
     SignUpDto invalidUserSignUpDto = this.buildValidSignUpDto();
     invalidUserSignUpDto.setPhone("12345678912345");

--- a/src/test/java/com/kh/bookfinder/controller/SignUpDuplicateCheckApiTest.java
+++ b/src/test/java/com/kh/bookfinder/controller/SignUpDuplicateCheckApiTest.java
@@ -1,0 +1,57 @@
+package com.kh.bookfinder.controller;
+
+import static org.hamcrest.core.Is.is;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kh.bookfinder.dto.DuplicateCheckDto;
+import com.kh.bookfinder.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@ActiveProfiles("test")
+@Transactional
+public class SignUpDuplicateCheckApiTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+  @Autowired
+  private ObjectMapper objectMapper;
+  @Autowired
+  private UserRepository userRepository;
+
+  @Test
+  @DisplayName("유효한 DuplicateCheckDto가 주어지는 경우")
+  public void emailDuplicateCheckSuccessTest() throws Exception {
+    // Given: field=email, value=jinho@kh.kr인 DuplicateCheckDto가 주어진다
+    DuplicateCheckDto validDuplicateCheckDto = DuplicateCheckDto
+        .builder()
+        .field("email")
+        .value("jinho@kh.kr")
+        .build();
+
+    // When: Duplicate Check API를 호출한다.
+    this.mockMvc
+        .perform(MockMvcRequestBuilders.get("/api/v1/signup/duplicate")
+            .param("field", validDuplicateCheckDto.getField())
+            .param("value", validDuplicateCheckDto.getValue())
+        )
+        // Then: Status는 200 Ok이다.
+        // And: message는 "가입이 가능한 이메일입니다."이다.
+        .andExpect(MockMvcResultMatchers.status().isOk())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.message", is("가입이 가능한 이메일입니다.")));
+  }
+
+}

--- a/src/test/java/com/kh/bookfinder/controller/SignUpDuplicateCheckApiTest.java
+++ b/src/test/java/com/kh/bookfinder/controller/SignUpDuplicateCheckApiTest.java
@@ -1,8 +1,10 @@
 package com.kh.bookfinder.controller;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.core.Is.is;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kh.bookfinder.constants.Message;
 import com.kh.bookfinder.dto.DuplicateCheckDto;
 import com.kh.bookfinder.repository.UserRepository;
 import jakarta.transaction.Transactional;
@@ -14,6 +16,7 @@ import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabas
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
@@ -24,6 +27,10 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 @ActiveProfiles("test")
 @Transactional
 public class SignUpDuplicateCheckApiTest {
+
+  /* TODO: 데이터베이스를 모킹해야할까? 아니면 실제 테스트이니 모킹할 필요 없나?
+           중복된 이메일인 경우, Bad Request가 나을까? 아니면 Conflict(409)가 나을까?
+   */
 
   @Autowired
   private MockMvc mockMvc;
@@ -54,4 +61,78 @@ public class SignUpDuplicateCheckApiTest {
         .andExpect(MockMvcResultMatchers.jsonPath("$.message", is("가입이 가능한 이메일입니다.")));
   }
 
+  @Test
+  @DisplayName("email 형식이 유효하지 않은 경우")
+  public void emailDuplicateCheckFailTest1() throws Exception {
+    // Given: field=email, value=jinhokhkr인 DuplicateCheckDto가 주어진다
+    DuplicateCheckDto invalidDuplicateCheckDto = DuplicateCheckDto
+        .builder()
+        .field("email")
+        .value("jinhokhkr")
+        .build();
+
+    // When: Duplicate Check API를 호출한다.
+    this.mockMvc
+        .perform(MockMvcRequestBuilders.get("/api/v1/signup/duplicate")
+            .param("field", invalidDuplicateCheckDto.getField())
+            .param("value", invalidDuplicateCheckDto.getValue())
+        )
+        // Then: Status는 400 Bad Request 이다.
+        // And: message는 "요청이 유효하지 않습니다. 다시 한번 확인해주세요."
+        // And: details는 {"email": "유효하지 않은 이메일 형식입니다."}이다.
+        .andExpect(MockMvcResultMatchers.status().isBadRequest())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.message", is(Message.BAD_REQUEST)))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.details.email", is(Message.INVALID_EMAIL)));
+  }
+
+  @Test
+  @DisplayName("field가 email이 아닌 경우")
+  public void emailDuplicateCheckFailTest2() throws Exception {
+    // Given: field=invalid, value=jinho@kh.kr인 DuplicateCheckDto가 주어진다
+    DuplicateCheckDto invalidDuplicateCheckDto = DuplicateCheckDto
+        .builder()
+        .field("invalid")
+        .value("jinho@kh.kr")
+        .build();
+
+    // When: Duplicate Check API를 호출한다.
+    this.mockMvc
+        .perform(MockMvcRequestBuilders.get("/api/v1/signup/duplicate")
+            .param("field", invalidDuplicateCheckDto.getField())
+            .param("value", invalidDuplicateCheckDto.getValue())
+        )
+        // Then: Status는 400 Bad Request 이다.
+        // And: message는 "요청이 유효하지 않습니다. 다시 한번 확인해주세요."
+        // And: details는 {"field": "field는 email만 가능합니다."}이다.
+        .andExpect(MockMvcResultMatchers.status().isBadRequest())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.message", is(Message.BAD_REQUEST)))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.details.field", is(Message.INVALID_FIELD)));
+  }
+
+  @Test
+  @DisplayName("이미 가입한 email인 경우")
+  @Sql("classpath:oneUserInsert.sql")
+  public void emailDuplicateCheckFailTest3() throws Exception {
+    // Given: email이 jinho@kh.kr인 User를 데이터베이스에 추가한다.
+    assertThat(this.userRepository.findByEmail("jinho@kh.kr").orElse(null)).isNotNull();
+    // And: field=email, value=jinho@kh.kr인 DuplicateCheckDto가 주어진다
+    DuplicateCheckDto validDuplicateCheckDto = DuplicateCheckDto
+        .builder()
+        .field("email")
+        .value("jinho@kh.kr")
+        .build();
+
+    // When: Duplicate Check API를 호출한다.
+    this.mockMvc
+        .perform(MockMvcRequestBuilders.get("/api/v1/signup/duplicate")
+            .param("field", validDuplicateCheckDto.getField())
+            .param("value", validDuplicateCheckDto.getValue())
+        )
+        // Then: Status는 400 Bad Request 이다.
+        // And: message는 "요청이 유효하지 않습니다. 다시 한번 확인해주세요."
+        // And: details는 {"email": "이미 가입된 이메일입니다."}이다.
+        .andExpect(MockMvcResultMatchers.status().isBadRequest())
+        .andExpect(MockMvcResultMatchers.jsonPath("$.message", is(Message.BAD_REQUEST)))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.details.email", is(Message.DUPLICATE_EMAIL)));
+  }
 }

--- a/src/test/resources/oneUserInsert.sql
+++ b/src/test/resources/oneUserInsert.sql
@@ -1,0 +1,3 @@
+insert into user(create_date, user_id, address, email, nickname, password, phone, social_id, role)
+values (current_date, 1, "testAddress", "jinho@kh.kr", "nickname", "password", "01012345678", "testSocialId",
+        "ROLE_USER");


### PR DESCRIPTION
# 참고
#57 
#21 

# 인증 코드 메일 보내기 API
- 메일 관련 설정에 보안상 민감한 정보들이 있기 때문에 application-mail.yml 파일로 추출
  - 관련 설정은 private한 곳에 공유
- EmailAuth Entity 추가
  - EmailAuth
    - auth_id 
    - email
    - auth_code
    - expiration
    - auth_code와 email을 묶어 unique로 처리

# Issue
- 현재는 RDBMS(Mysql)을 사용하여 EmailAuth를 저장하고 있는데, 이후에 NoSQL(Redis) 학습 후 변경 예정

