### PR TITLE
JH-63: 인증 코드 확인 API 추가

### DIFF
--- a/src/main/java/com/kh/bookfinder/constants/Message.java
+++ b/src/main/java/com/kh/bookfinder/constants/Message.java
@@ -11,6 +11,7 @@ public interface Message {
 
   String VALID_EMAIL = "가입이 가능한 이메일입니다.";
   String INVALID_EMAIL = "유효하지 않은 이메일 형식입니다.";
+  String MAIL_SUBJECT = "북적북적에서 보내는 이메일 인증 코드입니다.";
   String DUPLICATE_EMAIL = "이미 가입된 이메일입니다.";
   String INVALID_FIELD = "field는 email이나 nickname만 가능합니다.";
   String INVALID_PASSWORD = "영문, 숫자, 특수기호를 포함하여 8자 이상 20자 이하로 입력해주세요.";
@@ -19,6 +20,9 @@ public interface Message {
   String VALID_NICKNAME = "가입이 가능한 닉네임입니다.";
   String DUPLICATE_NICKNAME = "이미 가입된 닉네임입니다.";
   String INVALID_PHONE = "유효하지 않은 휴대폰 번호 형식입니다.";
+  String INVALID_AUTH_CODE = "유효하지 않은 인증 코드입니다.";
+  String EXPIRED_AUTH_CODE = "인증 코드가 만료되었습니다.";
+  String INVALID_SIGNING_TOKEN = "유효하지 않은 토큰입니다.";
 
   String INVALID_ISBN_DIGITS = "ISBN 번호는 13자리의 숫자만 입력 가능합니다.";
   String INVALID_ISBN = "유효하지 않은 ISBN 번호 입니다.";

--- a/src/main/java/com/kh/bookfinder/constants/Regexp.java
+++ b/src/main/java/com/kh/bookfinder/constants/Regexp.java
@@ -6,4 +6,5 @@ public interface Regexp {
   String PASSWORD = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[!@#$%^&*()-_=+]).{8,20}$";
   String NICKNAME = "^[가-힣a-zA-Z0-9]{3,20}$";
   String PHONE = "^01[0-9][0-9]{3,4}[0-9]{4}$";
+  String AUTH_CODE = "^[a-zA-Z0-9]{8}$";
 }

--- a/src/main/java/com/kh/bookfinder/controller/UserController.java
+++ b/src/main/java/com/kh/bookfinder/controller/UserController.java
@@ -1,6 +1,7 @@
 package com.kh.bookfinder.controller;
 
 import com.kh.bookfinder.constants.Message;
+import com.kh.bookfinder.dto.CheckingVerificationDto;
 import com.kh.bookfinder.dto.DuplicateCheckDto;
 import com.kh.bookfinder.dto.SendingEmailAuthDto;
 import com.kh.bookfinder.dto.SignUpDto;
@@ -59,6 +60,18 @@ public class UserController {
 
     JSONObject responseBody = new JSONObject();
     responseBody.put("signingToken", signingToken);
+
+    return ResponseEntity
+        .ok()
+        .body(responseBody.toString());
+  }
+
+  @PostMapping(value = "/verification-code", produces = "application/json;charset=UTF-8")
+  public ResponseEntity<String> checkVerification(@Valid @RequestBody CheckingVerificationDto requestBody)
+      throws JSONException {
+    String singingToken = this.emailAuthService.checkVerification(requestBody);
+    JSONObject responseBody = new JSONObject();
+    responseBody.put("signingToken", singingToken);
 
     return ResponseEntity
         .ok()

--- a/src/main/java/com/kh/bookfinder/dto/CheckingVerificationDto.java
+++ b/src/main/java/com/kh/bookfinder/dto/CheckingVerificationDto.java
@@ -1,9 +1,17 @@
 package com.kh.bookfinder.dto;
 
+import com.kh.bookfinder.constants.Message;
+import com.kh.bookfinder.constants.Regexp;
+import jakarta.validation.constraints.AssertTrue;
+import jakarta.validation.constraints.Pattern;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.springframework.boot.configurationprocessor.json.JSONException;
+import org.springframework.boot.configurationprocessor.json.JSONObject;
 
 @Data
 @AllArgsConstructor
@@ -11,6 +19,7 @@ import lombok.NoArgsConstructor;
 @Builder
 public class CheckingVerificationDto {
 
+  @Pattern(regexp = Regexp.AUTH_CODE, message = Message.INVALID_AUTH_CODE)
   private String authCode;
   private String signingToken;
 }

--- a/src/main/java/com/kh/bookfinder/dto/CheckingVerificationDto.java
+++ b/src/main/java/com/kh/bookfinder/dto/CheckingVerificationDto.java
@@ -1,0 +1,16 @@
+package com.kh.bookfinder.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class CheckingVerificationDto {
+
+  private String authCode;
+  private String signingToken;
+}

--- a/src/main/java/com/kh/bookfinder/dto/CheckingVerificationDto.java
+++ b/src/main/java/com/kh/bookfinder/dto/CheckingVerificationDto.java
@@ -22,4 +22,17 @@ public class CheckingVerificationDto {
   @Pattern(regexp = Regexp.AUTH_CODE, message = Message.INVALID_AUTH_CODE)
   private String authCode;
   private String signingToken;
+
+  @AssertTrue(message = Message.INVALID_SIGNING_TOKEN)
+  private boolean isSigningToken() {
+    String decoded = new String(Base64.getDecoder().decode(signingToken), StandardCharsets.UTF_8);
+    try {
+      JSONObject result = new JSONObject(decoded);
+      result.get("email");
+      result.get("code");
+      return true;
+    } catch (JSONException e) {
+      return false;
+    }
+  }
 }

--- a/src/main/java/com/kh/bookfinder/entity/EmailAuth.java
+++ b/src/main/java/com/kh/bookfinder/entity/EmailAuth.java
@@ -34,7 +34,7 @@ public class EmailAuth implements Serializable {
 
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
-  private Long auth_id;
+  private Long authId;
   @Default
   private String authCode = generateAuthCode();
   private String email;

--- a/src/main/java/com/kh/bookfinder/repository/EmailAuthRepository.java
+++ b/src/main/java/com/kh/bookfinder/repository/EmailAuthRepository.java
@@ -1,9 +1,10 @@
 package com.kh.bookfinder.repository;
 
 import com.kh.bookfinder.entity.EmailAuth;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EmailAuthRepository extends JpaRepository<EmailAuth, Long> {
 
-  EmailAuth findByEmailAndAuthCode(String email, String authCode);
+  Optional<EmailAuth> findByEmailAndAuthCode(String email, String authCode);
 }

--- a/src/main/java/com/kh/bookfinder/repository/EmailAuthRepository.java
+++ b/src/main/java/com/kh/bookfinder/repository/EmailAuthRepository.java
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface EmailAuthRepository extends JpaRepository<EmailAuth, Long> {
 
+  EmailAuth findByEmailAndAuthCode(String email, String authCode);
 }

--- a/src/main/java/com/kh/bookfinder/service/EmailAuthService.java
+++ b/src/main/java/com/kh/bookfinder/service/EmailAuthService.java
@@ -1,11 +1,13 @@
 package com.kh.bookfinder.service;
 
+import com.kh.bookfinder.constants.Message;
 import com.kh.bookfinder.dto.CheckingVerificationDto;
 import com.kh.bookfinder.entity.EmailAuth;
 import com.kh.bookfinder.exception.InvalidFieldException;
 import com.kh.bookfinder.repository.EmailAuthRepository;
 import jakarta.transaction.Transactional;
 import java.nio.charset.StandardCharsets;
+import java.time.LocalDateTime;
 import java.util.Base64;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.configurationprocessor.json.JSONException;
@@ -19,7 +21,6 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class EmailAuthService {
 
-  private final static String MAIL_SUBJECT = "북적북적에서 보내는 이메일 인증 코드입니다.";
   private final JavaMailSender emailSender;
   private final EmailAuthRepository emailAuthRepository;
 
@@ -32,7 +33,7 @@ public class EmailAuthService {
 
     SimpleMailMessage emailForm = new SimpleMailMessage();
     emailForm.setTo(targetEmail);
-    emailForm.setSubject(MAIL_SUBJECT);
+    emailForm.setSubject(Message.MAIL_SUBJECT);
     emailForm.setText(emailAuth.getAuthCode());
     emailSender.send(emailForm);
 
@@ -44,7 +45,16 @@ public class EmailAuthService {
     String signingTokenEmail = decoded.getString("email");
     String signingTokenAuthCode = decoded.getString("code");
 
-    EmailAuth target = this.emailAuthRepository.findByEmailAndAuthCode(signingTokenEmail, signingTokenAuthCode);
+    if (!signingTokenAuthCode.equals(requestBody.getAuthCode())) {
+      throw new InvalidFieldException("signingToken", Message.INVALID_SIGNING_TOKEN);
+    }
+
+    EmailAuth target = this.emailAuthRepository.findByEmailAndAuthCode(signingTokenEmail, signingTokenAuthCode)
+        .orElseThrow(() -> new InvalidFieldException("signingToken", Message.INVALID_SIGNING_TOKEN));
+
+    if (LocalDateTime.now().isAfter(target.getExpiration())) {
+      throw new InvalidFieldException("authCode", Message.EXPIRED_AUTH_CODE);
+    }
 
     return target.generateSigningToken();
   }

--- a/src/main/java/com/kh/bookfinder/service/EmailAuthService.java
+++ b/src/main/java/com/kh/bookfinder/service/EmailAuthService.java
@@ -59,16 +59,8 @@ public class EmailAuthService {
     return target.generateSigningToken();
   }
 
-  private JSONObject decode(String signingToken) {
+  private JSONObject decode(String signingToken) throws JSONException {
     String decoded = new String(Base64.getDecoder().decode(signingToken), StandardCharsets.UTF_8);
-    try {
-      JSONObject result = new JSONObject(decoded);
-      result.get("email");
-      result.get("code");
-
-      return result;
-    } catch (JSONException e) {
-      throw new InvalidFieldException("signingToken", "signing Token이 유효하지 않습니다.");
-    }
+    return new JSONObject(decoded);
   }
 }

--- a/src/test/java/com/kh/bookfinder/controller/CheckVerificationAuthCodeTest.java
+++ b/src/test/java/com/kh/bookfinder/controller/CheckVerificationAuthCodeTest.java
@@ -1,0 +1,76 @@
+package com.kh.bookfinder.controller;
+
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kh.bookfinder.dto.CheckingVerificationDto;
+import com.kh.bookfinder.entity.EmailAuth;
+import com.kh.bookfinder.repository.EmailAuthRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class CheckVerificationAuthCodeTest {
+
+  /*
+  {
+   "email": "jinho4744@naver.com",
+   "code": "dwf8yFrX"
+  }
+   */
+  private static final String MOCK_SIGNING_TOKEN = "eyJlbWFpbCI6ImppbmhvNDc0NEBuYXZlci5jb20iLCJjb2RlIjoiZHdmOHlGclgifQ==";
+  private static final String MOCK_AUTH_CODE = "dwf8yFrX";
+  @Autowired
+  private MockMvc mockMvc;
+  @Autowired
+  private ObjectMapper objectMapper;
+  private EmailAuth mockEmailAuth;
+  @MockBean
+  private EmailAuthRepository emailAuthRepository;
+
+  @BeforeEach
+  public void setup() {
+    mockEmailAuth = EmailAuth.builder()
+        .email("jinho4744@naver.com")
+        .authCode(MOCK_AUTH_CODE)
+        .build();
+  }
+
+  @Test
+  @DisplayName("유효한 authCode와 signingToken이 주어진 경우")
+  public void checkVerificationAuthCodeSuccessTest() throws Exception {
+    // Given: 유효한 CheckingVerificationDto가 주어진다.
+    CheckingVerificationDto requestDto = CheckingVerificationDto
+        .builder()
+        .authCode(MOCK_AUTH_CODE)
+        .signingToken(MOCK_SIGNING_TOKEN)
+        .build();
+    String requestBody = objectMapper.writeValueAsString(requestDto);
+    // And: EmailAuthRepository를 mocking 한다.
+    when(emailAuthRepository.findByEmailAndAuthCode(anyString(), anyString()))
+        .thenReturn(mockEmailAuth);
+
+    // When: Check Verification Auth Code API를 호출한다.
+    mockMvc.perform(MockMvcRequestBuilders
+        .post("/api/v1/signup/verification-code")
+        .content(requestBody)
+        .contentType(MediaType.APPLICATION_JSON)
+    )
+        // Then: Status는 200 Ok이다.
+        .andExpect(MockMvcResultMatchers.status().isOk())
+        // And: Response Body로 signingToken을 반환한다.
+        .andExpect(MockMvcResultMatchers.jsonPath("$.signingToken", is(MOCK_SIGNING_TOKEN)));
+  }
+}

--- a/src/test/java/com/kh/bookfinder/controller/CheckVerificationAuthCodeTest.java
+++ b/src/test/java/com/kh/bookfinder/controller/CheckVerificationAuthCodeTest.java
@@ -5,9 +5,12 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kh.bookfinder.constants.Message;
 import com.kh.bookfinder.dto.CheckingVerificationDto;
 import com.kh.bookfinder.entity.EmailAuth;
 import com.kh.bookfinder.repository.EmailAuthRepository;
+import java.time.LocalDateTime;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -60,7 +63,7 @@ public class CheckVerificationAuthCodeTest {
     String requestBody = objectMapper.writeValueAsString(requestDto);
     // And: EmailAuthRepository를 mocking 한다.
     when(emailAuthRepository.findByEmailAndAuthCode(anyString(), anyString()))
-        .thenReturn(mockEmailAuth);
+        .thenReturn(Optional.of(mockEmailAuth));
 
     // When: Check Verification Auth Code API를 호출한다.
     mockMvc.perform(MockMvcRequestBuilders
@@ -72,5 +75,129 @@ public class CheckVerificationAuthCodeTest {
         .andExpect(MockMvcResultMatchers.status().isOk())
         // And: Response Body로 signingToken을 반환한다.
         .andExpect(MockMvcResultMatchers.jsonPath("$.signingToken", is(MOCK_SIGNING_TOKEN)));
+  }
+
+  @Test
+  @DisplayName("유효하지 않은 authCode가 주어진 경우")
+  public void checkVerificationAuthCodeFailOnInvalidAuthCodeTest() throws Exception {
+    // Given: 유효하지 않은 CheckingVerificationDto가 주어진다.
+    CheckingVerificationDto invalidCheckingVerificationDto = CheckingVerificationDto
+        .builder()
+        .authCode("invalidAuthCode")
+        .signingToken(MOCK_SIGNING_TOKEN)
+        .build();
+    String requestBody = objectMapper.writeValueAsString(invalidCheckingVerificationDto);
+
+    // When: Check Verification Auth Code API를 호출한다.
+    mockMvc.perform(MockMvcRequestBuilders
+        .post("/api/v1/signup/verification-code")
+        .content(requestBody)
+        .contentType(MediaType.APPLICATION_JSON)
+    )
+        // Then: Status는 400 Bad Request이다.
+        .andExpect(MockMvcResultMatchers.status().isBadRequest())
+        // And: Response Body로 message와 details가 반환한다.
+        .andExpect(MockMvcResultMatchers.jsonPath("$.message", is(Message.BAD_REQUEST)))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.details.authCode", is(Message.INVALID_AUTH_CODE)));
+  }
+
+  @Test
+  @DisplayName("유효하지 않은 signingToken이 주어진 경우")
+  public void checkVerificationAuthCodeFailOnInvalidSigningTokenTest() throws Exception {
+    // Given: 유효하지 않은 CheckingVerificationDto가 주어진다.
+    CheckingVerificationDto invalidCheckingVerificationDto = CheckingVerificationDto
+        .builder()
+        .authCode(MOCK_AUTH_CODE)
+        .signingToken("InvalidSigningToken")
+        .build();
+    String requestBody = objectMapper.writeValueAsString(invalidCheckingVerificationDto);
+
+    // When: Check Verification Auth Code API를 호출한다.
+    mockMvc.perform(MockMvcRequestBuilders
+        .post("/api/v1/signup/verification-code")
+        .content(requestBody)
+        .contentType(MediaType.APPLICATION_JSON)
+    )
+        // Then: Status는 400 Bad Request이다.
+        .andExpect(MockMvcResultMatchers.status().isBadRequest())
+        // And: Response Body로 message와 details가 반환한다.
+        .andExpect(MockMvcResultMatchers.jsonPath("$.message", is(Message.BAD_REQUEST)))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.details.signingToken", is(Message.INVALID_SIGNING_TOKEN)));
+  }
+
+  @Test
+  @DisplayName("authCode와 signingToken의 authCode가 일치하지 않는 경우")
+  public void checkVerificationAuthCodeFailOnNotEqualAuthCodeTest() throws Exception {
+    // Given: authCode와 SigningToken의 authCode가 일치하지 않은 CheckingVerificationDto가 주어진다.
+    CheckingVerificationDto invalidCheckingVerificationDto = CheckingVerificationDto
+        .builder()
+        .authCode("Abcd1eFg")
+        .signingToken(MOCK_SIGNING_TOKEN)
+        .build();
+    String requestBody = objectMapper.writeValueAsString(invalidCheckingVerificationDto);
+
+    // When: Check Verification Auth Code API를 호출한다.
+    mockMvc.perform(MockMvcRequestBuilders
+        .post("/api/v1/signup/verification-code")
+        .content(requestBody)
+        .contentType(MediaType.APPLICATION_JSON)
+    )
+        // Then: Status는 400 Bad Request이다.
+        .andExpect(MockMvcResultMatchers.status().isBadRequest())
+        // And: Response Body로 message와 details가 반환한다.
+        .andExpect(MockMvcResultMatchers.jsonPath("$.message", is(Message.BAD_REQUEST)))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.details.signingToken", is(Message.INVALID_SIGNING_TOKEN)));
+  }
+
+  @Test
+  @DisplayName("signingToken의 email과 authCode가 db에 없는 경우")
+  public void checkVerificationAuthCodeFailOnNotExistInDbTest() throws Exception {
+    // Given: CheckingVerificationDto가 주어진다.
+    CheckingVerificationDto invalidCheckingVerificationDto = CheckingVerificationDto
+        .builder()
+        .authCode(MOCK_AUTH_CODE)
+        .signingToken(MOCK_SIGNING_TOKEN)
+        .build();
+    String requestBody = objectMapper.writeValueAsString(invalidCheckingVerificationDto);
+
+    // When: Check Verification Auth Code API를 호출한다.
+    mockMvc.perform(MockMvcRequestBuilders
+        .post("/api/v1/signup/verification-code")
+        .content(requestBody)
+        .contentType(MediaType.APPLICATION_JSON)
+    )
+        // Then: Status는 400 Bad Request이다.
+        .andExpect(MockMvcResultMatchers.status().isBadRequest())
+        // And: Response Body로 message와 details가 반환한다.
+        .andExpect(MockMvcResultMatchers.jsonPath("$.message", is(Message.BAD_REQUEST)))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.details.signingToken", is(Message.INVALID_SIGNING_TOKEN)));
+  }
+
+  @Test
+  @DisplayName("authCode의 expiration이 지난 경우")
+  public void checkVerificationAuthCodeFailOnExpirationAuthCodeTest() throws Exception {
+    // Given: CheckingVerificationDto가 주어진다.
+    CheckingVerificationDto invalidCheckingVerificationDto = CheckingVerificationDto
+        .builder()
+        .authCode(MOCK_AUTH_CODE)
+        .signingToken(MOCK_SIGNING_TOKEN)
+        .build();
+    String requestBody = objectMapper.writeValueAsString(invalidCheckingVerificationDto);
+    // EmailAuthRepository를 mocking 한다.
+    mockEmailAuth.setExpiration(LocalDateTime.now().minusMinutes(1));
+    when(emailAuthRepository.findByEmailAndAuthCode(anyString(), anyString()))
+        .thenReturn(Optional.of(mockEmailAuth));
+
+    // When: Check Verification Auth Code API를 호출한다.
+    mockMvc.perform(MockMvcRequestBuilders
+        .post("/api/v1/signup/verification-code")
+        .content(requestBody)
+        .contentType(MediaType.APPLICATION_JSON)
+    )
+        // Then: Status는 400 Bad Request이다.
+        .andExpect(MockMvcResultMatchers.status().isBadRequest())
+        // And: Response Body로 message와 details가 반환한다.
+        .andExpect(MockMvcResultMatchers.jsonPath("$.message", is(Message.BAD_REQUEST)))
+        .andExpect(MockMvcResultMatchers.jsonPath("$.details.authCode", is(Message.EXPIRED_AUTH_CODE)));
   }
 }


### PR DESCRIPTION
# 참고
#63 

# 인증 코드 확인 API
- 인증 코드 이메일 API로 이메일 받은 인증 코드와 Response의 signingToken 이용
- signingToken을 디코딩 → email과 authCode가 담긴 json 형태의 문자열
- 검증 단계
  - signingToken을 디코딩할 때 email과 authCode가 담긴 json 형태의 문자열이 올바르게 되는지
  - 이메일로 받은 인증 코드와 authCode가 일치하는지
  - email과 authCode에 대한 튜플이 EmailAuth 테이블에 있는지
  - 해당하는 EmailAuth 튜플의 Expiration이 지났는지

# Issue
- 인증 코드 확인 API에 따라 회원 가입 API도 수정이 필요함
- #64 