### PR TITLE
KE-70: BookTrade Entity 및 DTO 타입 변경

### DIFF
--- a/src/main/java/com/kh/bookfinder/dto/BookTradeDTO.java
+++ b/src/main/java/com/kh/bookfinder/dto/BookTradeDTO.java
@@ -5,6 +5,7 @@ import com.kh.bookfinder.entity.TradeType;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
 import java.util.Date;
 import lombok.Data;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -23,7 +24,7 @@ public class BookTradeDTO {
   @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
   private Date limitedDate;
   private String content;
-  private float latitude;
-  private float longitude;
+  private BigDecimal latitude;
+  private BigDecimal longitude;
 
 }

--- a/src/main/java/com/kh/bookfinder/entity/BookTrade.java
+++ b/src/main/java/com/kh/bookfinder/entity/BookTrade.java
@@ -9,6 +9,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
+import java.math.BigDecimal;
 import java.util.Date;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -42,8 +43,10 @@ public class BookTrade {
   @Column(nullable = false)
   private int rentalCost;
   private String content;
-  private float latitude;
-  private float longitude;
+  @Column(precision = 10, scale = 8)
+  private BigDecimal latitude;
+  @Column(precision = 11, scale = 8)
+  private BigDecimal longitude;
   private Date limitedDate;
   @Enumerated(EnumType.STRING)
   @Builder.Default


### PR DESCRIPTION
# BookTrade Entity 및 DTO 타입 변경
- 기존의 float로 소수점 8자리까지 저장이 되지 않아서 BigDecimal로 타입 변경했습니다.