### PR TITLE
JH-0: 리팩토링

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,14 @@ request body (application/json)
     }
     ```
 
+---
+
 ## BookTrade
+
 ### Create BookTrade API
+
 **Request**
+
 ```
 POST: {BASE_URL}/api/v1/trades
 
@@ -163,3 +168,52 @@ GET: {BASE_URL}/api/v1/trades/list/{boroughId}
         }
     }
     ```
+
+### Get BookTrade API
+
+**Request**
+
+```
+GET: {BASE_URL}/api/v1/trades/{tradeId}
+```
+
+**Response**
+
+- 200 Ok
+    ```
+    {
+        "id": 1,
+        "tradeType": "BORROW",
+        "tradeYn": "N",
+        "content": "책 빌려주세요.",
+        "rentalCost": 10000,
+        "longitude": 18.12342,
+        "latitude": 19.12115,
+        "createdDate": "2024-05-15"
+        "book": {
+            "name": "test book name1",
+            "authors": "test book authors1 etc..",
+            "publisher": "test publisher1",
+            "publicationYear": 2024
+            "imageUrl": "test url3"
+            "description": "test description"
+        }
+        "user": {
+            "nickname": "고소하게"
+        }
+    }
+    ```
+
+- 404 Not Found
+    - boroughId에 대한 튜플이 DB에 없는 경우
+      ```
+      {
+          "message": "거래 번호를 찾을 수 없습니다."
+      }
+      ```
+    - boroughId에 대한 튜플의 상태가 Delete인 경우
+      ```
+      {
+          "message": "삭제된 게시물 입니다."
+      }
+      ```

--- a/README.md
+++ b/README.md
@@ -20,28 +20,28 @@ request body (application/json)
 
 **Response**
 - 201 Created
-```
-{
-  "message": "회원 가입 성공!\n환영합니다\n.로그인 후 이용해 주세요."
-}
-```
+    ```
+    {
+      "message": "회원 가입 성공!\n환영합니다\n.로그인 후 이용해 주세요."
+    }
+    ```
 
 - 400 Bad Request
-```
-{
-  "message": "요청이 유효하지 않습니다. 다시 한번 확인해 주세요."
-  "details": {
-      "email": "유효하지 않은 이메일 형식입니다.",
-      "email": "이미 가입된 이메일입니다.",
-      "password": "영문, 숫자, 특수기호를 포함하여 8자 이상 20자 이하로 입력해주세요.",
-      "password": "비밀번호와 비밀번호 확인이 일치하지 않습니다.",
-      "nickname": "영문, 유효한 한글, 숫자를 이용하여 3자 이상 10자 이하로 입력해주세요.",
-      "nickname": "이미 가입된 닉네임입니다.",
-      "address": "주소는 서울시로 시작해야 합니다.",
-      "phone": "유효하지 않은 휴대폰 번호 형식입니다"
-  }
-}
-```
+    ```
+    {
+      "message": "요청이 유효하지 않습니다. 다시 한번 확인해 주세요."
+      "details": {
+          "email": "유효하지 않은 이메일 형식입니다.",
+          "email": "이미 가입된 이메일입니다.",
+          "password": "영문, 숫자, 특수기호를 포함하여 8자 이상 20자 이하로 입력해주세요.",
+          "password": "비밀번호와 비밀번호 확인이 일치하지 않습니다.",
+          "nickname": "영문, 유효한 한글, 숫자를 이용하여 3자 이상 10자 이하로 입력해주세요.",
+          "nickname": "이미 가입된 닉네임입니다.",
+          "address": "주소는 서울시로 시작해야 합니다.",
+          "phone": "유효하지 않은 휴대폰 번호 형식입니다"
+      }
+    }
+    ```
 
 ## BookTrade
 ### Create BookTrade API
@@ -62,7 +62,9 @@ request body (application/json)
 ```
 
 **Response**
+
 - 201 Created
+
 ```
 {
   "message": "정상적으로 등록되었습니다."
@@ -70,3 +72,94 @@ request body (application/json)
 ```
 
 - 400 Bad Request
+
+### List BookTrade API
+
+**Request**
+
+```
+GET: {BASE_URL}/api/v1/trades/list/{boroughId}
+```
+
+**Response**
+
+- 200 Ok
+    - 데이터가 있는 경우
+        ```
+        {
+          [
+            {
+                "id": 1,
+                "tradeType": "BORROW",
+                "tradeYn": "N",
+                "rentalCost": 10000,
+                "createdDate": "2024-05-02",
+                "user": {
+                    "nickname": "testNick1"
+                }
+                "book": {
+                    "name": "test book name1",
+                    "authors": "test book authors1 etc..",
+                    "publicationYear": 2024
+                    "imageUrl": "test url1"
+                }
+                "borough": {
+                    "name": "강남구"
+                }
+            },
+                {
+                "id": 2,
+                "tradeType": "RENT",
+                "tradeYn": "N",
+                "rentalCost": 13000,
+                "createdDate": "2024-05-02",
+                "user": {
+                    "nickname": "testNick2"
+                }
+                "book": {
+                    "name": "test book name2",
+                    "authors": "test book authors2 etc..",
+                    "publicationYear": 2024
+                    "imageUrl": "test url2"
+                }
+                "borough": {
+                    "name": "강남구"
+                }
+            },
+                {
+                "id": 1,
+                "tradeType": "BORROW",
+                "tradeYn": "Y",
+                "rentalCost": 5000,
+                "createdDate": "2024-05-02",
+                "user": {
+                    "nickname": "testNick1"
+                }
+                "book": {
+                    "name": "test book name3",
+                    "authors": "test book authors3 etc..",
+                    "publicationYear": 2024
+                    "imageUrl": "test url3"
+                }
+                "borough": {
+                    "name": "강남구"
+                }
+            },
+            ...
+          ]
+        }
+        ```
+    - 데이터가 없는 경우
+        ```
+            []
+        ```
+
+- 400 Bad Request
+    ```
+    {
+        "message": "요청이 유효하지 않습니다. 다시 한번 확인해주세요."
+        "details": {
+            "boroughId": "지역 번호는 1부터 25까지의 숫자만 입력 가능합니다."          
+        }
+    }
+    ```

--- a/src/main/java/com/kh/bookfinder/book/service/BookService.java
+++ b/src/main/java/com/kh/bookfinder/book/service/BookService.java
@@ -1,9 +1,9 @@
 package com.kh.bookfinder.book.service;
 
-import com.kh.bookfinder.global.constants.Message;
 import com.kh.bookfinder.book.dto.SearchDto;
 import com.kh.bookfinder.book.entity.Book;
 import com.kh.bookfinder.book.repository.BookRepository;
+import com.kh.bookfinder.global.constants.Message;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;

--- a/src/main/java/com/kh/bookfinder/book_trade/controller/BookTradeController.java
+++ b/src/main/java/com/kh/bookfinder/book_trade/controller/BookTradeController.java
@@ -1,16 +1,19 @@
 package com.kh.bookfinder.book_trade.controller;
 
+import com.kh.bookfinder.book.entity.Book;
+import com.kh.bookfinder.book.service.BookService;
+import com.kh.bookfinder.book_trade.dto.BookTradeRequestDto;
+import com.kh.bookfinder.book_trade.dto.BookTradeResponseDto;
+import com.kh.bookfinder.book_trade.entity.BookTrade;
+import com.kh.bookfinder.book_trade.service.BookTradeService;
 import com.kh.bookfinder.global.constants.Borough;
 import com.kh.bookfinder.global.constants.Message;
-import com.kh.bookfinder.book_trade.dto.BookTradeDto;
-import com.kh.bookfinder.book.entity.Book;
-import com.kh.bookfinder.book_trade.entity.BookTrade;
 import com.kh.bookfinder.global.exception.InvalidFieldException;
-import com.kh.bookfinder.book.service.BookService;
-import com.kh.bookfinder.book_trade.service.BookTradeService;
 import jakarta.validation.Valid;
 import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -31,13 +34,18 @@ public class BookTradeController {
   private final BookTradeService bookTradeService;
   private final BookService bookService;
 
-  @GetMapping("list/{boroughId}")
-  public ResponseEntity<ArrayList<BookTrade>> getBookTrades(@PathVariable(name = "boroughId") Long boroughId) {
-    if (boroughId < Borough.MIN_BOROUGH || boroughId > Borough.MAX_BOROUGH) {
-      throw new InvalidFieldException("borough Id", Message.INVALID_BOROUGH);
+  @GetMapping(value = "list/{boroughId}", produces = "application/json;charset=UTF-8")
+  public ResponseEntity<List<BookTradeResponseDto>> getBookTrades(@PathVariable(name = "boroughId") Long boroughId) {
+    if (!isValidBoroughId(boroughId)) {
+      throw new InvalidFieldException("boroughId", Message.INVALID_BOROUGH);
     }
     ArrayList<BookTrade> bookTradeList = bookTradeService.getBookTrades(boroughId);
-    return ResponseEntity.ok().body(bookTradeList);
+
+    List<BookTradeResponseDto> response = bookTradeList.stream().map(
+        BookTrade::toResponseDto
+    ).collect(Collectors.toList());
+
+    return ResponseEntity.ok().body(response);
   }
 
   @GetMapping("/{tradeId}")
@@ -47,18 +55,9 @@ public class BookTradeController {
   }
 
   @PostMapping
-  public ResponseEntity<BookTrade> createBookTrade(@RequestBody @Valid BookTradeDto tradeDto) {
+  public ResponseEntity<BookTrade> createBookTrade(@RequestBody @Valid BookTradeRequestDto tradeDto) {
     Book book = bookService.findBook(tradeDto.getIsbn());
-
-    BookTrade bookTrade = BookTrade.builder()
-        .book(book)
-        .tradeType(tradeDto.getTradeType())
-        .rentalCost(tradeDto.getRentalCost())
-        .limitedDate(tradeDto.getLimitedDate())
-        .content(tradeDto.getContent())
-        .latitude(tradeDto.getLatitude())
-        .longitude(tradeDto.getLongitude())
-        .build();
+    BookTrade bookTrade = tradeDto.toEntity(book);
 
     bookTradeService.saveBookTrade(bookTrade);
     return ResponseEntity.status(HttpStatus.CREATED).build();
@@ -66,7 +65,7 @@ public class BookTradeController {
 
   @PutMapping("/{tradeId}")
   public ResponseEntity<Map<String, String>> updateBookTrade(@PathVariable(name = "tradeId") Long tradeId,
-      @RequestBody @Valid BookTradeDto tradeDto) {
+      @RequestBody @Valid BookTradeRequestDto tradeDto) {
     BookTrade bookTrade = bookTradeService.findTrade(tradeId);
     Book book = bookService.findBook(tradeDto.getIsbn());
 
@@ -90,6 +89,10 @@ public class BookTradeController {
   public ResponseEntity<Map<String, String>> deleteBookTrade(@PathVariable(name = "tradeId") Long tradeId) {
     bookTradeService.deleteTrade(tradeId);
     return ResponseEntity.ok().body(Map.of("message", Message.SUCCESS_DELETE));
+  }
+
+  private boolean isValidBoroughId(Long boroughId) {
+    return boroughId >= Borough.MIN_BOROUGH && boroughId <= Borough.MAX_BOROUGH;
   }
 
 }

--- a/src/main/java/com/kh/bookfinder/book_trade/controller/BookTradeController.java
+++ b/src/main/java/com/kh/bookfinder/book_trade/controller/BookTradeController.java
@@ -2,8 +2,9 @@ package com.kh.bookfinder.book_trade.controller;
 
 import com.kh.bookfinder.book.entity.Book;
 import com.kh.bookfinder.book.service.BookService;
+import com.kh.bookfinder.book_trade.dto.BookTradeDetailResponseDto;
+import com.kh.bookfinder.book_trade.dto.BookTradeListResponseDto;
 import com.kh.bookfinder.book_trade.dto.BookTradeRequestDto;
-import com.kh.bookfinder.book_trade.dto.BookTradeResponseDto;
 import com.kh.bookfinder.book_trade.entity.BookTrade;
 import com.kh.bookfinder.book_trade.entity.Borough;
 import com.kh.bookfinder.book_trade.service.BookTradeService;
@@ -35,23 +36,24 @@ public class BookTradeController {
   private final BookService bookService;
 
   @GetMapping(value = "list/{boroughId}", produces = "application/json;charset=UTF-8")
-  public ResponseEntity<List<BookTradeResponseDto>> getBookTrades(@PathVariable(name = "boroughId") Long boroughId) {
+  public ResponseEntity<List<BookTradeListResponseDto>> getBookTrades(
+      @PathVariable(name = "boroughId") Long boroughId) {
     if (!Borough.isValid(boroughId)) {
       throw new InvalidFieldException("boroughId", Message.INVALID_BOROUGH);
     }
     ArrayList<BookTrade> bookTradeList = bookTradeService.getBookTrades(boroughId);
 
-    List<BookTradeResponseDto> response = bookTradeList.stream().map(
-        BookTrade::toResponseDto
+    List<BookTradeListResponseDto> response = bookTradeList.stream().map(
+        x -> x.toResponse(BookTradeListResponseDto.class)
     ).collect(Collectors.toList());
 
     return ResponseEntity.ok().body(response);
   }
 
   @GetMapping("/{tradeId}")
-  public ResponseEntity<BookTrade> getBookTrade(@PathVariable(name = "tradeId") Long tradeId) {
+  public ResponseEntity<BookTradeDetailResponseDto> getBookTrade(@PathVariable(name = "tradeId") Long tradeId) {
     BookTrade bookTrade = bookTradeService.getBookTrade(tradeId);
-    return ResponseEntity.ok().body(bookTrade);
+    return ResponseEntity.ok().body(bookTrade.toResponse(BookTradeDetailResponseDto.class));
   }
 
   @PostMapping

--- a/src/main/java/com/kh/bookfinder/book_trade/controller/BookTradeController.java
+++ b/src/main/java/com/kh/bookfinder/book_trade/controller/BookTradeController.java
@@ -5,8 +5,8 @@ import com.kh.bookfinder.book.service.BookService;
 import com.kh.bookfinder.book_trade.dto.BookTradeRequestDto;
 import com.kh.bookfinder.book_trade.dto.BookTradeResponseDto;
 import com.kh.bookfinder.book_trade.entity.BookTrade;
+import com.kh.bookfinder.book_trade.entity.Borough;
 import com.kh.bookfinder.book_trade.service.BookTradeService;
-import com.kh.bookfinder.global.constants.Borough;
 import com.kh.bookfinder.global.constants.Message;
 import com.kh.bookfinder.global.exception.InvalidFieldException;
 import jakarta.validation.Valid;
@@ -36,7 +36,7 @@ public class BookTradeController {
 
   @GetMapping(value = "list/{boroughId}", produces = "application/json;charset=UTF-8")
   public ResponseEntity<List<BookTradeResponseDto>> getBookTrades(@PathVariable(name = "boroughId") Long boroughId) {
-    if (!isValidBoroughId(boroughId)) {
+    if (!Borough.isValid(boroughId)) {
       throw new InvalidFieldException("boroughId", Message.INVALID_BOROUGH);
     }
     ArrayList<BookTrade> bookTradeList = bookTradeService.getBookTrades(boroughId);
@@ -90,9 +90,4 @@ public class BookTradeController {
     bookTradeService.deleteTrade(tradeId);
     return ResponseEntity.ok().body(Map.of("message", Message.SUCCESS_DELETE));
   }
-
-  private boolean isValidBoroughId(Long boroughId) {
-    return boroughId >= Borough.MIN_BOROUGH && boroughId <= Borough.MAX_BOROUGH;
-  }
-
 }

--- a/src/main/java/com/kh/bookfinder/book_trade/dto/BookTradeDetailResponseDto.java
+++ b/src/main/java/com/kh/bookfinder/book_trade/dto/BookTradeDetailResponseDto.java
@@ -1,0 +1,52 @@
+package com.kh.bookfinder.book_trade.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import com.kh.bookfinder.book_trade.entity.Status;
+import com.kh.bookfinder.book_trade.entity.TradeType;
+import java.math.BigDecimal;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class BookTradeDetailResponseDto {
+
+  private Long id;
+  private Integer rentalCost;
+  private String content;
+  private BigDecimal longitude;
+  private BigDecimal latitude;
+  private TradeType tradeType;
+  private Status tradeYn;
+  @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd")
+  private Date createdDate;
+  private Map<String, Object> user = new HashMap<>();
+  private Map<String, Object> book = new HashMap<>();
+
+  @Builder
+  public BookTradeDetailResponseDto(Long id, TradeType tradeType, Status tradeYn, String content,
+      Integer rentalCost, BigDecimal longitude, BigDecimal latitude, Date createdDate,
+      String bookName, String bookAuthors, String bookPublisher, String bookImageUrl, String bookDescription,
+      Integer bookPublicationYear, String userNickname) {
+    this.id = id;
+    this.tradeType = tradeType;
+    this.tradeYn = tradeYn;
+    this.content = content;
+    this.rentalCost = rentalCost;
+    this.longitude = longitude;
+    this.latitude = latitude;
+    this.createdDate = createdDate;
+
+    this.book.put("name", bookName);
+    this.book.put("authors", bookAuthors);
+    this.book.put("publisher", bookPublisher);
+    this.book.put("publicationYear", bookPublicationYear);
+    this.book.put("imageUrl", bookImageUrl);
+    this.book.put("description", bookDescription);
+
+    this.user.put("nickname", userNickname);
+  }
+}

--- a/src/main/java/com/kh/bookfinder/book_trade/dto/BookTradeListResponseDto.java
+++ b/src/main/java/com/kh/bookfinder/book_trade/dto/BookTradeListResponseDto.java
@@ -11,7 +11,7 @@ import lombok.Builder;
 import lombok.Data;
 
 @Data
-public class BookTradeResponseDto {
+public class BookTradeListResponseDto {
 
   private Long id;
   private TradeType tradeType;
@@ -24,7 +24,7 @@ public class BookTradeResponseDto {
   private Map<String, Object> borough = new HashMap<>();
 
   @Builder
-  public BookTradeResponseDto(Long id, TradeType tradeType, Status tradeYn, Integer rentalCost, Date createdDate,
+  public BookTradeListResponseDto(Long id, TradeType tradeType, Status tradeYn, Integer rentalCost, Date createdDate,
       String bookName, String bookAuthors, Integer bookPublicationYear, String bookImageUrl,
       String userNickname,
       String boroughName) {

--- a/src/main/java/com/kh/bookfinder/book_trade/dto/BookTradeRequestDto.java
+++ b/src/main/java/com/kh/bookfinder/book_trade/dto/BookTradeRequestDto.java
@@ -1,7 +1,9 @@
 package com.kh.bookfinder.book_trade.dto;
 
-import com.kh.bookfinder.global.constants.Message;
+import com.kh.bookfinder.book.entity.Book;
+import com.kh.bookfinder.book_trade.entity.BookTrade;
 import com.kh.bookfinder.book_trade.entity.TradeType;
+import com.kh.bookfinder.global.constants.Message;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
@@ -10,7 +12,7 @@ import java.util.Date;
 import lombok.Data;
 
 @Data
-public class BookTradeDto {
+public class BookTradeRequestDto {
 
   @Min(value = 1000000000000L, message = Message.INVALID_ISBN_DIGITS)
   @Max(value = 9999999999999L, message = Message.INVALID_ISBN_DIGITS)
@@ -25,4 +27,15 @@ public class BookTradeDto {
   private BigDecimal latitude;
   private BigDecimal longitude;
 
+  public BookTrade toEntity(Book book) {
+    return BookTrade.builder()
+        .book(book)
+        .tradeType(this.tradeType)
+        .rentalCost(this.rentalCost)
+        .limitedDate(this.limitedDate)
+        .content(this.content)
+        .latitude(this.latitude)
+        .longitude(this.longitude)
+        .build();
+  }
 }

--- a/src/main/java/com/kh/bookfinder/book_trade/dto/BookTradeResponseDto.java
+++ b/src/main/java/com/kh/bookfinder/book_trade/dto/BookTradeResponseDto.java
@@ -1,0 +1,43 @@
+package com.kh.bookfinder.book_trade.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonFormat.Shape;
+import com.kh.bookfinder.book_trade.entity.Status;
+import com.kh.bookfinder.book_trade.entity.TradeType;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+public class BookTradeResponseDto {
+
+  private Long id;
+  private TradeType tradeType;
+  private Status tradeYn;
+  private Integer rentalCost;
+  @JsonFormat(shape = Shape.STRING, pattern = "yyyy-MM-dd")
+  private Date createdDate;
+  private Map<String, Object> book = new HashMap<>();
+  private Map<String, Object> user = new HashMap<>();
+  private Map<String, Object> borough = new HashMap<>();
+
+  @Builder
+  public BookTradeResponseDto(Long id, TradeType tradeType, Status tradeYn, Integer rentalCost, Date createdDate,
+      String bookName, String bookAuthors, Integer bookPublicationYear, String bookImageUrl,
+      String userNickname,
+      String boroughName) {
+    this.id = id;
+    this.tradeType = tradeType;
+    this.tradeYn = tradeYn;
+    this.rentalCost = rentalCost;
+    this.createdDate = createdDate;
+    this.book.put("name", bookName);
+    this.book.put("authors", bookAuthors);
+    this.book.put("publicationYear", bookPublicationYear);
+    this.book.put("imageUrl", bookImageUrl);
+    this.user.put("nickname", userNickname);
+    this.borough.put("name", boroughName);
+  }
+}

--- a/src/main/java/com/kh/bookfinder/book_trade/entity/BookTrade.java
+++ b/src/main/java/com/kh/bookfinder/book_trade/entity/BookTrade.java
@@ -1,6 +1,7 @@
 package com.kh.bookfinder.book_trade.entity;
 
 import com.kh.bookfinder.book.entity.Book;
+import com.kh.bookfinder.book_trade.dto.BookTradeResponseDto;
 import com.kh.bookfinder.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -61,4 +62,19 @@ public class BookTrade {
   @UpdateTimestamp
   private Date updateDate;
 
+  public BookTradeResponseDto toResponseDto() {
+    return BookTradeResponseDto.builder()
+        .id(this.id)
+        .tradeType(this.tradeType)
+        .tradeYn(this.tradeYn)
+        .rentalCost(this.rentalCost)
+        .createdDate(this.createDate)
+        .bookName(this.book.getName())
+        .bookAuthors(this.book.getAuthors())
+        .bookPublicationYear(this.book.getPublicationYear())
+        .bookImageUrl(this.book.getImageUrl())
+        .userNickname(this.user.getNickname())
+        .boroughName(this.borough.getName())
+        .build();
+  }
 }

--- a/src/main/java/com/kh/bookfinder/book_trade/entity/BookTrade.java
+++ b/src/main/java/com/kh/bookfinder/book_trade/entity/BookTrade.java
@@ -1,7 +1,8 @@
 package com.kh.bookfinder.book_trade.entity;
 
 import com.kh.bookfinder.book.entity.Book;
-import com.kh.bookfinder.book_trade.dto.BookTradeResponseDto;
+import com.kh.bookfinder.book_trade.dto.BookTradeDetailResponseDto;
+import com.kh.bookfinder.book_trade.dto.BookTradeListResponseDto;
 import com.kh.bookfinder.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -62,8 +63,40 @@ public class BookTrade {
   @UpdateTimestamp
   private Date updateDate;
 
-  public BookTradeResponseDto toResponseDto() {
-    return BookTradeResponseDto.builder()
+
+  public <T> T toResponse(Class<T> responseType) {
+    if (responseType == BookTradeListResponseDto.class) {
+      return (T) this.toListResponseDto();
+    } else if (responseType == BookTradeDetailResponseDto.class) {
+      return (T) this.toDetailResponseDto();
+    }
+    return null;
+  }
+
+  private BookTradeDetailResponseDto toDetailResponseDto() {
+    return BookTradeDetailResponseDto.builder()
+        .id(this.id)
+        .tradeType(this.tradeType)
+        .tradeYn(this.tradeYn)
+        .content(this.content)
+        .rentalCost(this.rentalCost)
+        .longitude(this.longitude)
+        .latitude(this.latitude)
+        .createdDate(this.createDate)
+
+        .bookName(this.book.getName())
+        .bookAuthors(this.book.getAuthors())
+        .bookPublisher(this.book.getPublisher())
+        .bookPublicationYear(this.book.getPublicationYear())
+        .bookImageUrl(this.book.getImageUrl())
+        .bookDescription(this.book.getDescription())
+
+        .userNickname(this.user.getNickname())
+        .build();
+  }
+
+  private BookTradeListResponseDto toListResponseDto() {
+    return BookTradeListResponseDto.builder()
         .id(this.id)
         .tradeType(this.tradeType)
         .tradeYn(this.tradeYn)

--- a/src/main/java/com/kh/bookfinder/book_trade/entity/Borough.java
+++ b/src/main/java/com/kh/bookfinder/book_trade/entity/Borough.java
@@ -5,10 +5,16 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 
 @Data
 @Entity
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
 public class Borough {
 
   @Id

--- a/src/main/java/com/kh/bookfinder/book_trade/entity/Borough.java
+++ b/src/main/java/com/kh/bookfinder/book_trade/entity/Borough.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Transient;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -17,6 +18,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class Borough {
 
+  @Transient
+  private static int MIN_BOROUGH = 1;
+  @Transient
+  private static int MAX_BOROUGH = 25;
+
   @Id
   @Column(name = "BOROUGH_ID")
   @GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,4 +30,7 @@ public class Borough {
   @Column(unique = true, nullable = false)
   private String name;
 
+  public static boolean isValid(Long id) {
+    return id >= MIN_BOROUGH && id <= MAX_BOROUGH;
+  }
 }

--- a/src/main/java/com/kh/bookfinder/global/constants/Borough.java
+++ b/src/main/java/com/kh/bookfinder/global/constants/Borough.java
@@ -1,7 +1,0 @@
-package com.kh.bookfinder.global.constants;
-
-public interface Borough {
-
-  int MIN_BOROUGH = 1;
-  int MAX_BOROUGH = 25;
-}

--- a/src/main/java/com/kh/bookfinder/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kh/bookfinder/global/exception/GlobalExceptionHandler.java
@@ -32,7 +32,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
   }
 
   @ExceptionHandler(InvalidFieldException.class)
-  public ResponseEntity<Object> handleInvalidField(InvalidFieldException e) {
+  public ResponseEntity<ErrorResponseBody> handleInvalidField(InvalidFieldException e) {
     ErrorResponseBody errorResponseBody = ErrorResponseBody.builder()
         .message(Message.BAD_REQUEST)
         .details(extractDetailsForField(e))
@@ -43,7 +43,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
   }
 
   @ExceptionHandler(ResourceNotFoundException.class)
-  public ResponseEntity<Object> handleResourceNotFound(ResourceNotFoundException e) {
+  public ResponseEntity<ErrorResponseBody> handleResourceNotFound(ResourceNotFoundException e) {
     ErrorResponseBody errorResponseBody = ErrorResponseBody.builder()
         .message(e.getLocalizedMessage())
         .build();

--- a/src/main/java/com/kh/bookfinder/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kh/bookfinder/global/exception/GlobalExceptionHandler.java
@@ -4,7 +4,9 @@ import com.kh.bookfinder.global.constants.Message;
 import com.kh.bookfinder.global.dto.ErrorResponseBody;
 import java.util.HashMap;
 import java.util.Map;
+import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
@@ -37,6 +39,16 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
         .build();
     return ResponseEntity
         .badRequest()
+        .body(errorResponseBody);
+  }
+
+  @ExceptionHandler(ResourceNotFoundException.class)
+  public ResponseEntity<Object> handleResourceNotFound(ResourceNotFoundException e) {
+    ErrorResponseBody errorResponseBody = ErrorResponseBody.builder()
+        .message(e.getLocalizedMessage())
+        .build();
+    return ResponseEntity
+        .status(HttpStatus.NOT_FOUND)
         .body(errorResponseBody);
   }
 

--- a/src/main/java/com/kh/bookfinder/user/controller/UserController.java
+++ b/src/main/java/com/kh/bookfinder/user/controller/UserController.java
@@ -9,9 +9,9 @@ import com.kh.bookfinder.user.entity.EmailAuth;
 import com.kh.bookfinder.user.service.EmailAuthService;
 import com.kh.bookfinder.user.service.UserService;
 import jakarta.validation.Valid;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.configurationprocessor.json.JSONException;
-import org.springframework.boot.configurationprocessor.json.JSONObject;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,52 +29,41 @@ public class UserController {
   private final EmailAuthService emailAuthService;
 
   @PostMapping(value = "", produces = "application/json;charset=UTF-8")
-  public ResponseEntity<String> signUp(@RequestBody @Valid SignUpDto signUpDto)
-      throws JSONException {
+  public ResponseEntity<Map<String, String>> signUp(@RequestBody @Valid SignUpDto signUpDto) {
     userService.save(signUpDto);
-    JSONObject responseBody = new JSONObject();
-    responseBody.put("message", Message.SIGNUP_SUCCESS);
 
     return ResponseEntity
         .status(HttpStatus.CREATED)
-        .body(responseBody.toString());
+        .body(Map.of("message", Message.SIGNUP_SUCCESS));
   }
 
   @GetMapping(value = "/duplicate", produces = "application/json;charset=UTF-8")
-  public ResponseEntity<String> checkDuplicate(@Valid DuplicateCheckDto duplicateCheckDto)
-      throws JSONException {
+  public ResponseEntity<Map<String, String>> checkDuplicate(@Valid DuplicateCheckDto duplicateCheckDto) {
     userService.checkDuplicate(duplicateCheckDto);
-    JSONObject responseBody = new JSONObject();
 
-    responseBody.put("message", Message.getSuccessMessageBy(duplicateCheckDto.getField()));
     return ResponseEntity
         .ok()
-        .body(responseBody.toString());
+        .body(Map.of("message", Message.getSuccessMessageBy(duplicateCheckDto.getField())));
   }
 
   @PostMapping(value = "/email", produces = "application/json;charset=UTF-8")
-  public ResponseEntity<String> sendAuthEmail(@Valid @RequestBody SendingEmailAuthDto requestBody)
+  public ResponseEntity<Map<String, String>> sendAuthEmail(@Valid @RequestBody SendingEmailAuthDto requestBody)
       throws JSONException {
     EmailAuth emailAuth = this.emailAuthService.sendAuthCodeTo(requestBody.getEmail());
     String signingToken = emailAuth.generateSigningToken();
 
-    JSONObject responseBody = new JSONObject();
-    responseBody.put("signingToken", signingToken);
-
     return ResponseEntity
         .ok()
-        .body(responseBody.toString());
+        .body(Map.of("signingToken", signingToken));
   }
 
   @PostMapping(value = "/verification-code", produces = "application/json;charset=UTF-8")
-  public ResponseEntity<String> checkVerification(@Valid @RequestBody CheckingVerificationDto requestBody)
+  public ResponseEntity<Map<String, String>> checkVerification(@Valid @RequestBody CheckingVerificationDto requestBody)
       throws JSONException {
     String singingToken = this.emailAuthService.checkVerification(requestBody);
-    JSONObject responseBody = new JSONObject();
-    responseBody.put("signingToken", singingToken);
 
     return ResponseEntity
         .ok()
-        .body(responseBody.toString());
+        .body(Map.of("signingToken", singingToken));
   }
 }

--- a/src/test/java/com/kh/bookfinder/book_trade/api/GetBookTradeOneApiTest.java
+++ b/src/test/java/com/kh/bookfinder/book_trade/api/GetBookTradeOneApiTest.java
@@ -1,0 +1,80 @@
+package com.kh.bookfinder.book_trade.api;
+
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kh.bookfinder.book_trade.dto.BookTradeDetailResponseDto;
+import com.kh.bookfinder.book_trade.entity.BookTrade;
+import com.kh.bookfinder.book_trade.helper.MockBookTrade;
+import com.kh.bookfinder.book_trade.repository.BookTradeRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@ActiveProfiles("test")
+public class GetBookTradeOneApiTest {
+
+  @Autowired
+  private ObjectMapper objectMapper;
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  private BookTradeRepository bookTradeRepository;
+
+  @Test
+  @DisplayName("유효한 BookTrade Id가 주어졌을 때")
+  public void getBookTradeOneSuccessOnValidId() throws Exception {
+    // Given: 유효한 BookTrade Id가 주어진다.
+    long tradeId = 1;
+    // And: Mock BookTrade가 주어진다.
+    BookTrade mockBookTrade = MockBookTrade.getMockBookTrade();
+    when(bookTradeRepository.findById(tradeId))
+        .thenReturn(Optional.of(mockBookTrade));
+
+    // When: Get BookTrade API를 호출한다.
+    ResultActions resultActions = mockMvc
+        .perform(MockMvcRequestBuilders
+            .get("/api/v1/trades/{tradeId}", tradeId));
+
+    // Then: Status는 200 Ok이다.
+    resultActions.andExpect(MockMvcResultMatchers.status().isOk());
+    // And: Response Body로 BookTrade 1개를 반환한다.
+    String expected = objectMapper.writeValueAsString(mockBookTrade.toResponse(BookTradeDetailResponseDto.class));
+    resultActions.andExpect(MockMvcResultMatchers.content().json(expected));
+    checkDetailResponseDto(resultActions);
+  }
+
+  private void checkDetailResponseDto(ResultActions resultActions) throws Exception {
+    resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.id").exists());
+    resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.tradeType").exists());
+    resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.tradeYn").exists());
+    resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.content").exists());
+    resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.rentalCost").exists());
+    resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.longitude").exists());
+    resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.latitude").exists());
+    resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.createdDate").exists());
+    resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.book.name").exists());
+    resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.book.authors").exists());
+    resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.book.publisher").exists());
+    resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.book.publicationYear").exists());
+    resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.book.imageUrl").exists());
+    resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.book.description").exists());
+    resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.user.nickname").exists());
+  }
+}

--- a/src/test/java/com/kh/bookfinder/book_trade/api/ListBookTradeApiTest.java
+++ b/src/test/java/com/kh/bookfinder/book_trade/api/ListBookTradeApiTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kh.bookfinder.book_trade.dto.BookTradeListResponseDto;
 import com.kh.bookfinder.book_trade.entity.BookTrade;
 import com.kh.bookfinder.book_trade.helper.MockBookTrade;
 import com.kh.bookfinder.book_trade.service.BookTradeService;
@@ -83,7 +84,7 @@ public class ListBookTradeApiTest {
     String expected = objectMapper.writeValueAsString(
         mockBookTrades
             .stream()
-            .map(BookTrade::toResponseDto)
+            .map(x -> x.toResponse(BookTradeListResponseDto.class))
             .collect(Collectors.toList())
     );
     resultActions.andExpect(MockMvcResultMatchers.content().json(expected));

--- a/src/test/java/com/kh/bookfinder/book_trade/api/ListBookTradeApiTest.java
+++ b/src/test/java/com/kh/bookfinder/book_trade/api/ListBookTradeApiTest.java
@@ -3,14 +3,14 @@ package com.kh.bookfinder.book_trade.api;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
-import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kh.bookfinder.book_trade.dto.BookTradeListResponseDto;
 import com.kh.bookfinder.book_trade.entity.BookTrade;
+import com.kh.bookfinder.book_trade.entity.Status;
 import com.kh.bookfinder.book_trade.helper.MockBookTrade;
-import com.kh.bookfinder.book_trade.service.BookTradeService;
+import com.kh.bookfinder.book_trade.repository.BookTradeRepository;
 import com.kh.bookfinder.global.constants.Message;
 import java.util.ArrayList;
 import java.util.stream.Collectors;
@@ -43,7 +43,7 @@ public class ListBookTradeApiTest {
   @Autowired
   private MockMvc mockMvc;
   @MockBean
-  private BookTradeService bookTradeService;
+  private BookTradeRepository bookTradeRepository;
 
   @Test
   @DisplayName("DB에 저장된 BookTrade 튜플이 없는 경우")
@@ -66,9 +66,9 @@ public class ListBookTradeApiTest {
   public void listBookTradeSuccessOnExistBookTradeList() throws Exception {
     // Given: 유효한 Borough ID가 주어진다
     // And: Mock BookTrade List가 주어진다.
-    int boroughId = 1;
+    Long boroughId = 1L;
     ArrayList<BookTrade> mockBookTrades = MockBookTrade.getMockBookTradeList(10);
-    when(this.bookTradeService.getBookTrades(any()))
+    when(this.bookTradeRepository.findByBoroughIdAndDeleteYn(boroughId, Status.N))
         .thenReturn(mockBookTrades);
 
     // When: List BookTrade API를 호출한다.

--- a/src/test/java/com/kh/bookfinder/book_trade/api/ListBookTradeApiTest.java
+++ b/src/test/java/com/kh/bookfinder/book_trade/api/ListBookTradeApiTest.java
@@ -1,0 +1,109 @@
+package com.kh.bookfinder.book_trade.api;
+
+
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kh.bookfinder.book_trade.entity.BookTrade;
+import com.kh.bookfinder.book_trade.helper.MockBookTrade;
+import com.kh.bookfinder.book_trade.service.BookTradeService;
+import com.kh.bookfinder.global.constants.Message;
+import java.util.ArrayList;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@ActiveProfiles("test")
+public class ListBookTradeApiTest {
+
+  // 유저 간 책 대출 API, List
+
+  @Autowired
+  private ObjectMapper objectMapper;
+  @Autowired
+  private MockMvc mockMvc;
+  @MockBean
+  private BookTradeService bookTradeService;
+
+  @Test
+  @DisplayName("DB에 저장된 BookTrade 튜플이 없는 경우")
+  public void listBookTradeSuccessOnEmptyBookTradeList() throws Exception {
+    // Given: 유효한 Borough ID가 주어진다
+    int boroughId = 1;
+
+    // When: List BookTrade API를 호출한다.
+    ResultActions resultActions = mockMvc
+        .perform(MockMvcRequestBuilders
+            .get("/api/v1/trades/list/{boroughId}", boroughId));
+    // Then: Status는 200이다.
+    resultActions.andExpect(MockMvcResultMatchers.status().isOk());
+    // And: Response Body로 BookTrade List를 반환한다. (Empty)
+    resultActions.andExpect(MockMvcResultMatchers.jsonPath("$").isEmpty());
+  }
+
+  @Test
+  @DisplayName("DB에 BookTrade 튜플이 있는 경우")
+  public void listBookTradeSuccessOnExistBookTradeList() throws Exception {
+    // Given: 유효한 Borough ID가 주어진다
+    // And: Mock BookTrade List가 주어진다.
+    int boroughId = 1;
+    ArrayList<BookTrade> mockBookTrades = MockBookTrade.getMockBookTradeList(10);
+    when(this.bookTradeService.getBookTrades(any()))
+        .thenReturn(mockBookTrades);
+
+    // When: List BookTrade API를 호출한다.
+    ResultActions resultActions = mockMvc
+        .perform(MockMvcRequestBuilders
+            .get("/api/v1/trades/list/{boroughId}", boroughId));
+
+    // Then: Status는 200 Ok 이다.
+    resultActions.andExpect(MockMvcResultMatchers.status().isOk());
+    // And: Response Body로 10개의 BookTrade List를 반환한다.
+    resultActions.andExpect(MockMvcResultMatchers.jsonPath("$", hasSize(10)));
+    // And: list는 jsonExpected와 같다.
+    String expected = objectMapper.writeValueAsString(
+        mockBookTrades
+            .stream()
+            .map(BookTrade::toResponseDto)
+            .collect(Collectors.toList())
+    );
+    resultActions.andExpect(MockMvcResultMatchers.content().json(expected));
+  }
+
+  @Test
+  @DisplayName("유효하지 않은 boroughId가 주어진 경우")
+  public void listBookTradeFailOnInvalidBoroughId() throws Exception {
+    // Given: 유효하지 않은 Borough ID가 주어진다
+    int invalidBoroughId = 28;
+
+    // When: List BookTrade API를 호출한다.
+    ResultActions resultActions = mockMvc
+        .perform(MockMvcRequestBuilders
+            .get("/api/v1/trades/list/{boroughId}", invalidBoroughId));
+
+    // Then: Status는 400 Bad Request 이다.
+    resultActions.andExpect(MockMvcResultMatchers.status().isBadRequest());
+    // And: Response Body로 message와 details를 반환한다.
+    resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.message", is(Message.BAD_REQUEST)));
+    resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.details.boroughId", is(Message.INVALID_BOROUGH)));
+  }
+}

--- a/src/test/java/com/kh/bookfinder/book_trade/helper/MockBookTrade.java
+++ b/src/test/java/com/kh/bookfinder/book_trade/helper/MockBookTrade.java
@@ -14,6 +14,10 @@ import java.util.ArrayList;
 
 public class MockBookTrade {
 
+  public static BookTrade getMockBookTrade() {
+    return getMockBookTradeList(1).get(0);
+  }
+
   public static ArrayList<BookTrade> getMockBookTradeList(int count) {
     ArrayList<BookTrade> result = new ArrayList<>();
     User user = User.builder()
@@ -27,9 +31,10 @@ public class MockBookTrade {
         .createDate(Date.valueOf(LocalDate.now()))
         .build();
     Book book = Book.builder()
-        .isbn(123456789012L)
+        .isbn(1234567890123L)
         .name("test book name")
         .authors("test book authors")
+        .publisher("test book publisher")
         .publicationYear(2024)
         .description("test book description")
         .imageUrl("test book image url")

--- a/src/test/java/com/kh/bookfinder/book_trade/helper/MockBookTrade.java
+++ b/src/test/java/com/kh/bookfinder/book_trade/helper/MockBookTrade.java
@@ -1,0 +1,64 @@
+package com.kh.bookfinder.book_trade.helper;
+
+import com.kh.bookfinder.book.entity.Book;
+import com.kh.bookfinder.book_trade.entity.BookTrade;
+import com.kh.bookfinder.book_trade.entity.Borough;
+import com.kh.bookfinder.book_trade.entity.Status;
+import com.kh.bookfinder.book_trade.entity.TradeType;
+import com.kh.bookfinder.user.entity.User;
+import com.kh.bookfinder.user.entity.UserRole;
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.time.LocalDate;
+import java.util.ArrayList;
+
+public class MockBookTrade {
+
+  public static ArrayList<BookTrade> getMockBookTradeList(int count) {
+    ArrayList<BookTrade> result = new ArrayList<>();
+    User user = User.builder()
+        .id(1L)
+        .email("testEmail@test.co.kr")
+        .password("password")
+        .phone("01012345678")
+        .nickname("고소하게")
+        .address("서울시 관악구")
+        .role(UserRole.ROLE_ADMIN)
+        .createDate(Date.valueOf(LocalDate.now()))
+        .build();
+    Book book = Book.builder()
+        .isbn(123456789012L)
+        .name("test book name")
+        .authors("test book authors")
+        .publicationYear(2024)
+        .description("test book description")
+        .imageUrl("test book image url")
+        .build();
+    Borough borough = Borough
+        .builder()
+        .id(1L)
+        .name("관악구")
+        .build();
+    for (int i = 0; i < count; i++) {
+      BookTrade bookTrade = BookTrade
+          .builder()
+          .id((i + 1L))
+          .tradeType(TradeType.BORROW)
+          .tradeYn(Status.Y)
+          .deleteYn(Status.N)
+          .rentalCost(10000)
+          .content("test Content")
+          .latitude(BigDecimal.valueOf(12.3))
+          .longitude(BigDecimal.valueOf(23.4))
+          .limitedDate(Date.valueOf("2024-05-21"))
+          .createDate(Date.valueOf(LocalDate.now()))
+          .updateDate(Date.valueOf(LocalDate.now()))
+          .user(user)
+          .book(book)
+          .borough(borough)
+          .build();
+      result.add(bookTrade);
+    }
+    return result;
+  }
+}

--- a/src/test/resources/book.sql
+++ b/src/test/resources/book.sql
@@ -1,0 +1,979 @@
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9788931466591, null, '니시무라 야스히로 저 ;유세라 역', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.118', null,
+        'https://image.aladin.co.kr/product/29861/97/cover/8931466595_1.jpg', '(그림으로 배우는) 웹 구조 =Web technology ',
+        'Youngjin.com(영진닷컴)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9788931466928, null, '사카가미 코오다이 저 ;양성건 역', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.75', null,
+        'https://image.aladin.co.kr/product/29722/75/cover/8931466927_1.jpg', '(그림으로 배우는) 데이터베이스 =Database ',
+        'Youngjin.com(영진닷컴)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9788931467659, null, '유광명 저', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.12', null,
+        'https://image.aladin.co.kr/product/30591/58/cover/8931467656_1.jpg',
+        '(파이썬 코드로 배우는) Git & GitHub :협업하는 개발자를 위한 버전 관리 지침서 ', 'Youngjin.com(영진닷컴)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9788931467734, null, '저자: Christian Mayer ;번역: 유동환', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133',
+        null, 'https://image.aladin.co.kr/product/30891/96/cover/8931467737_1.jpg', '클린 코드의 기술 :단순함의 노하우 ', '영진닷컴');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9788931559842, null, '앤미디어 지음', '총류 > 총류 > 전산학', '004.73', null,
+        'https://image.aladin.co.kr/product/31452/30/cover/8931559844_1.jpg', '챗GPT & AI 활용법 ', 'BM성안당');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9788931559859, null, '한선관,김도용 지음', '총류 > 총류 > 전산학', '004.73', null,
+        'https://image.aladin.co.kr/product/31732/88/cover/8931559852_1.jpg', '챗GPT와 썸타기 :놀랄 만큼 쉬운 chatGPT 활용법 ',
+        'BM성안당');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93320, null, 2019, 9788950981839, null, '미노와 고스케 지음 ;구수영 옮김', '총류 > 도서학, 서지학 > ', '013', null,
+        'https://image.aladin.co.kr/product/19654/96/cover/8950981831_1.jpg',
+        '미치지 않고서야 :일본 천재 편집자가 들려주는 새로운 시대, 일하기 혁명 ', '21세기북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2018, 9788956747750, null, '박정태 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'http://image.aladin.co.kr/product/12864/10/cover/895674775x_1.jpg',
+        '파이썬으로 배우는 웹 크롤러 =파이썬 코드 조각으로 데이터 모으기 /Python web crawler ', '정보문화사');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (94560, null, 2012, 9788960773417, null, '이일민 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.135', null,
+        'http://image.aladin.co.kr/product/1950/55/cover/8960773417_1.jpg', '토비의 스프링 3.1', '에이콘출판');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (94000, null, 2015, 9788960777330, null, '김영한 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.115', null,
+        'http://image.aladin.co.kr/product/6268/14/cover/8960777331_1.jpg',
+        '(자바 ORM 표준) JPA 프로그래밍 :스프링 데이터 예제 프로젝트로 배우는 전자정부 표준 데이터베이스 프레임워크 ', '에이콘');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9788960883802, null, '집필: 비현코', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/27978/82/cover/8960883808_1.jpg', 'IT 비전공자를 위한 돈 버는 파이썬 코딩 :n잡러 자동부업 수익창출 ',
+        'Digital Books(디지털북스)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9788960883918, null, 'Nofair 저', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.13', null,
+        'https://image.aladin.co.kr/product/28487/60/cover/8960883913_1.jpg', '로블록스 게임 제작 점프맵 만들기 :roblox로 배우는 기초 코딩 ',
+        'Digital Books(디지털북스)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9788960883932, null, '윤준호 저', '총류 > 총류 > 전산학', '004.73', null,
+        'https://image.aladin.co.kr/product/28914/19/cover/896088393x_1.jpg', '(그림으로 이해하는 비전공자를 위한) 딥러닝 ',
+        'Digital Books(디지털북스)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9788960883949, null, '지은이: 주미니', '총류 > 총류 > 전산학', '004.586', null,
+        'https://image.aladin.co.kr/product/29044/81/cover/8960883948_1.jpg',
+        '블로그 포스팅 비법서 :먹고 여행하는 모든 일상을 상위 노출 컨텐츠로 업로드하라! ', 'Digital Books(디지털북스)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9788960884243, null, '권현욱 저', '총류 > 총류 > 전산학', '004.73', null,
+        'https://image.aladin.co.kr/product/31426/5/cover/8960884243_1.jpg',
+        '챗GPT + 엑셀 업무자동화 정석 :상품기획부터 계약서 작성하여 보고서까지~53가지 사례로 완성하는 ChatGPT ', 'Digital Books(디지털북스)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2019, 9788965402602, null, '이동욱 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.118', null,
+        'https://image.aladin.co.kr/product/21856/89/cover/8965402603_2.jpg',
+        '스프링 부트와 AWS로 혼자 구현하는 웹 서비스 :인텔리제이, JPA, JUnit 테스트, 그레이들, 소셜 로그인, AWS 인프라로 무중단 배포까지 ', '프리렉');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9788965403340, null, '구멍가게 코딩단 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.138', null,
+        'https://image.aladin.co.kr/product/29875/95/cover/8965403340_1.jpg', '자바 앱 개발 워크북 :성장하는 개발자를 만드는 실무형 로드맵 ',
+        '프리렉');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2015, 9788966261437, null, '이광근 지음', '총류 > 총류 > 전산학', '004', null,
+        'http://image.aladin.co.kr/product/5971/52/cover/8966261434_2.jpg',
+        '컴퓨터과학이 여는 세계 :세상을 바꾼 컴퓨터, 소프트웨어의 원천 아이디어 그리고 미래 ', '인사이트');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2018, 9788966262281, null, '조슈아 블로크 지음 ;개앞맵시 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/17119/64/cover/8966262287_1.jpg', '이펙티브 자바 ', '인사이트');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93410, null, 2020, 9788966262625, null, '강중빈 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.11', null,
+        'https://image.aladin.co.kr/product/24353/27/cover/8966262627_1.jpg', '수학 리부트 :프로그래머를 위한 기초 수학 ', '인사이트');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9788966263134, null, '댄 밴더캄 지음 ;장원호 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.138', null,
+        'https://image.aladin.co.kr/product/27319/31/cover/8966263135_1.jpg', '이펙티브 타입스크립트 :동작 원리의 이해와 구체적인 조언 62가지 ',
+        '인사이트');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9788966263158, null, '알렉스 쉬 지음 ;이병준 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.12', null,
+        'https://image.aladin.co.kr/product/27604/17/cover/8966263151_1.jpg', '(가상 면접 사례로 배우는) 대규모 시스템 설계 기초 ', '인사이트');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9788966263745, null, '유동균 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.138', null,
+        'https://image.aladin.co.kr/product/30437/18/cover/8966263747_1.jpg', '(웹 개발 스킬을 한 단계 높여 주는) 프론트엔드 성능 최적화 가이드 ',
+        '인사이트');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93500, null, 2023, 9788966263943, null, '이정환 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.118', null,
+        'https://image.aladin.co.kr/product/31379/25/cover/8966263941_1.jpg',
+        '(한 입 크기로 잘라 먹는) 리액트 :자바스크립트 기초부터 애플리케이션 배포까지 ', '인사이트');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9788966263998, null, '센바 다이야 지음 ;윤인성 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/31790/64/cover/8966263992_1.jpg',
+        '내 코드가 그렇게 이상한가요? :좋은 코드/나쁜 코드로 배우는 설계 입문 ', '인사이트');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9788966264148, null, '마틴 데이비스 지음 ;박상민 옮김', '총류 > 총류 > 전산학', '004', null,
+        'https://image.aladin.co.kr/product/32248/67/cover/896626414x_1.jpg',
+        '오늘날 우리는 컴퓨터라 부른다 :라이프니츠부터 튜링까지, 생각하는 기계의 씨앗을 뿌린 사람들 ', '인사이트');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2015, 9788968482311, null, '아사이 아츠시 지음 ;박준용 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.755', null,
+        'http://image.aladin.co.kr/product/6902/53/cover/8968482314_1.jpg',
+        'SQL 첫걸음 :하루 30분 36강으로 배우는 완전 초보의 SQL 따라잡기 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2016, 9788968482519, null, '미크 지음 ;윤인성 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.755', null,
+        'http://image.aladin.co.kr/product/7556/62/cover/8968482519_1.jpg', 'SQL 레벨업 :DB 성능 최적화를 위한 SQL 실전 가이드 ',
+        '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (94000, null, 2017, 9788968483547, null, '아디트야 바르가바 지음 ;김도형 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.11', null,
+        'http://image.aladin.co.kr/product/10598/25/cover/896848354x_1.jpg', '그림으로 개념을 이해하는 알고리즘 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2017, 9788968484636, null, '지은이: 사이토 고키 ;옮긴이: 개앞맵시', '총류 > 총류 > 전산학', '004.73', null,
+        'http://image.aladin.co.kr/product/9951/87/cover/8968484635_1.jpg', '밑바닥부터 시작하는 딥러닝 :파이썬으로 익히는 딥러닝 이론과 구현 ',
+        '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9788970505367, null, '반병현 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.118', null,
+        'https://image.aladin.co.kr/product/28858/41/cover/8970505369_1.jpg',
+        '(코딩만 따라 해도 웹페이지가 만들어지는) HTML+CSS+자바스크립트 ', '생능출판사');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93020, null, 2020, 9788976783806, null, '윤혜영 저', '총류 > 문헌정보학 > 수서, 정리 및 보관', '024.1', null,
+        'https://image.aladin.co.kr/product/24617/30/cover/8976783808_1.jpg',
+        '디지털시대의 장서관리 =Collection management in the digital age ', '한국도서관협회');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2017, 9788997924318, null, '히라야마 쯔요시,신상재 옮김', '총류 > 총류 > 전산학', '004.588', null,
+        'http://image.aladin.co.kr/product/10948/67/cover/8997924311_1.jpg', '(그림으로 배우는) 클라우드 인프라와 API의 구조 ', '로드북');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9788997924875, null, '지은이: 김효실', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/27310/75/cover/8997924877_1.jpg',
+        '파이썬 생활밀착형 프로젝트 :웹 크롤링, 카카오톡 메시지 보내기, 업무 자동화까지 11가지 파이썬 프로젝트 ', '로드북');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9788997924882, null, '지은이: 김설화,정종윤', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.104', null,
+        'https://image.aladin.co.kr/product/27889/98/cover/8997924885_1.jpg', '나는 주니어 개발자다 :청년 개발자 다섯의 성장 이야기 ', '로드북');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9788997924899, null, '지은이: 변구훈', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.118', null,
+        'https://image.aladin.co.kr/product/27860/11/cover/8997924893_1.jpg', '스프링 부트 쇼핑몰 프로젝트 with JPA ', '로드북');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9788997924905, null, '박민경 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.118', null,
+        'https://image.aladin.co.kr/product/28130/92/cover/8997924907_1.jpg', 'Node.js로 서버 만들기 ', '로드북');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9788997924974, null, '지은이: 박민경', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005', null,
+        'https://image.aladin.co.kr/product/29805/4/cover/8997924974_1.jpg', '개발자 상식 :개발자에겐 상식 비전공자에겐 고급지식 ', '로드북');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2015, 9788998139766, null, '조영호 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.115', null,
+        'https://bookthumb-phinf.pstatic.net/cover/091/459/09145968.jpg?type=m1&udate=20171011',
+        '객체지향의 사실과 오해 :역할, 책임, 협력 관점에서 본 객체지향 =The essence of object-orientation : roles, responsibilities, and collaborations ',
+        '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2015, 9788998139940, null, '김종민 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'http://image.aladin.co.kr/product/5564/19/cover/8998139944_1.jpg', '(스프링 입문을 위한) 자바 객체 지향의 원리와 이해 ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791140700691, null, '강민철 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.12', null,
+        'https://image.aladin.co.kr/product/29821/39/cover/k492838310_1.jpg',
+        '모두의 깃&깃허브 =누구나 쉽게 시작하는 git & github 버전 관리 /Git & github for everyones ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791140700943, null, '엘튼 스톤맨 지음 ;심효섭 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.1', null,
+        'https://image.aladin.co.kr/product/29918/47/cover/k212838436_1.jpg', '도커 교과서 ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791140701551, null, '나도코딩 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/30224/91/cover/k482839206_1.jpg',
+        '코딩 자율학습 나도코딩의 C 언어 입문 =스스로 하는 프로그래밍 공부 /C for beginners with Nadocoding ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791140702152, null, '이가라시 타카유키,성창규 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.11', null,
+        'https://image.aladin.co.kr/product/30517/65/cover/k422830491_1.jpg',
+        '그림으로 이해하는 가상화와 컨테이너 =Virtualization and container ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791140702787, null, '서지영 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.11', null,
+        'https://image.aladin.co.kr/product/30908/97/cover/k802831588_1.jpg',
+        '(쉽게 시작하는) 쿠버네티스 =Getting started Kubernetes ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791140702794, null, '김도연 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.76', null,
+        'https://image.aladin.co.kr/product/30883/28/cover/k792831388_1.jpg',
+        '모두의 구글 애널리틱스4 =GA4로 하는 디지털 마케팅 데이터 분석 /Google analytics4 for everyone ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791140703302, null, '나도코딩 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/31060/47/cover/k462831528_1.jpg',
+        '(코딩 자율학습) 나도코딩의 파이썬 입문 =초보자의 눈높이에 맞춘 친절한 프로그래밍 자습서 /Python for beginners with Nadocoding ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791140704156, null, '서지영 지음', '총류 > 총류 > 전산학', '004.73', null,
+        'https://image.aladin.co.kr/product/31478/10/cover/k722832521_1.jpg',
+        '챗GPT :개념 이해와 동작 원리부터 다양한 서비스와 활용법, 파인 튜닝, API까지 ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791140704521, null, '박조은,송영숙 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.76', null,
+        'https://image.aladin.co.kr/product/31728/72/cover/k492833897_1.jpg',
+        '모두의 한국어 텍스트 분석 with 파이썬 :기초부터 챗GPT까지, 누구나 쉽게 시작하는 자연어 처리 ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791140705184, null, '나카오 신지 지음 ;김성훈 옮김', '총류 > 총류 > 전산학', '004.5', null,
+        'https://image.aladin.co.kr/product/32065/59/cover/k312834896_1.jpg',
+        '(그림으로 이해하는) 네트워크 구조와 기술 =Structure and technology of network ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93800, null, 2020, 9791156332787, null, '마리아 포포바 지음 ;지여울 옮김', '총류 > 총류 > 지식, 학문 일반', '001.3', null,
+        'https://image.aladin.co.kr/product/23308/8/cover/k442637810_1.jpg', '진리의 발견 :앞서 나간 자들 ', '다른');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791157688050, null, '마스이 도시카츠 지음 ;박광수 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.1', null,
+        'https://image.aladin.co.kr/product/29396/45/cover/k562837512_1.jpg',
+        '(가장 쉬운 독학) 알고리즘 첫걸음 파이썬편 :코딩 테스트에 대비하는 25가지 기초 알고리즘과 최적화', '동양북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791157688197, null, '안겔 레오나르드 지음 ;시진 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.13', null,
+        'https://image.aladin.co.kr/product/29939/36/cover/k902838638_1.jpg',
+        '자바 코딩 인터뷰 완벽 가이드 :자바 프로그래머의 취업을 위한 258가지 코딩 인터뷰 & 테스트 ', '동양북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2019, 9791158391331, null, '이고잉 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.118', null,
+        'https://image.aladin.co.kr/product/17746/71/cover/k342534127_1.jpg',
+        '(처음 프로그래밍을 시작하는 입문자의 눈높이에 맞춘) 생활코딩! HTML+CSS+자바스크립트 :나의 첫 프로그래밍 교과서 learning school ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93500, null, 2019, 9791158391409, null, '조영호 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.115', null,
+        'https://image.aladin.co.kr/product/19368/10/cover/k972635015_1.jpg', '오브젝트 =코드로 이해하는 객체지향 설계 /Objects ',
+        '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2019, 9791158391720, null, '정재남 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.138', null,
+        'https://image.aladin.co.kr/product/20651/30/cover/k532636268_1.jpg',
+        '코어 자바스크립트 =핵심 개념과 동작 원리로 이해하는 자바스크립트 프로그래밍 /Core Javascript ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2020, 9791158391881, null, '박재현 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/23136/94/cover/k322637700_1.jpg',
+        '(파이썬과 리액트를 활용한) 주식 자동 거래 시스템 구축 :데이터 수집부터 거래 자동화, API 서버, 웹 개발, 데이터 분석까지 아우르는 ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2020, 9791158392024, null, '장용준 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/23794/93/cover/k452639080_1.jpg',
+        '(손가락 하나 까딱하지 않는) 주식 거래 시스템 구축 :파이썬을 이용한 데이터 수집과 차트 분석, 매매 자동화까지 ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2020, 9791158392093, null, '지은이: 조성봉 ;엮은이: 전이주', '총류 > 총류 > 전산학', '004.78', null,
+        'https://image.aladin.co.kr/product/24364/49/cover/k162630116_1.jpg',
+        '이것이 UX/UI 디자인이다 =실무 디자인 방법론으로서의 UX/UI 디자인 /This is UX/UI design ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2020, 9791158392239, null, '이웅모 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.138', null,
+        'https://image.aladin.co.kr/product/25155/25/cover/k282633473_1.jpg',
+        '모던 자바스크립트 deep dive :자바스크립트의 기본 개념과 동작 원리 ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2020, 9791158392260, null, '최은석 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/25468/22/cover/k992633822_1.jpg',
+        '(일 잘하는 직장인을 위한) 엑셀 자동화 with 파이썬 :복잡하고 지루한 반복 업무를 쉽고 빠르게 해치우는 방법 ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9791158392376, null, '이고잉 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.118', null,
+        'https://image.aladin.co.kr/product/26736/27/cover/k532730383_1.jpg',
+        '(처음 프로그래밍을 시작하는 입문자의 눈높이에 맞춘) 생활코딩! 리액트 프로그래밍 =React ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9791158392468, null, '한정헌,이주영 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.12', null,
+        'https://image.aladin.co.kr/product/26817/90/cover/k242730299_1.jpg',
+        '(도메인 주도 설계로 시작하는) 마이크로서비스 개발 :핵심 개념과 패턴, 설계, 구현으로 배우는 DDD와 MSA ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9791158392680, null, '에자키 타카히로 지음 ;손민규 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.76', null,
+        'https://image.aladin.co.kr/product/27747/94/cover/k542734762_1.jpg', '데이터 해석학 입문 :올바른 데이터 분석을 위한 의사결정 성공 방정식 ',
+        '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9791158392703, null, '백은빈,이성욱 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.7533', null,
+        'https://image.aladin.co.kr/product/27848/87/cover/k712734689_1.jpg',
+        'Real MySQL 8.0 :개발자와 DBA를 위한 MySQL 실전 가이드 ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791158393038, null, '오가사와라 시게타카 지음 ;심효섭 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.1', null,
+        'https://image.aladin.co.kr/product/29141/96/cover/k052837077_1.jpg',
+        '(그림과 실습으로 배우는) 도커 & 쿠버네티스 :개념과 작동 원리가 쏙쏙 이해되는 완벽 입문서 ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791158393083, null, '지은이: 장정우 ;엮은이: 이대엽', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.118', null,
+        'https://image.aladin.co.kr/product/29659/19/cover/k072838987_1.jpg',
+        '스프링 부트 핵심 가이드 :스프링 부트를 활용한 애플리케이션 개발 실무 ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93500, null, 2022, 9791158393229, null, '권철민 지음', '총류 > 총류 > 전산학', '004.73', null,
+        'https://image.aladin.co.kr/product/29260/15/cover/k212837700_1.jpg',
+        '파이썬 머신러닝 완벽 가이드 :다양한 캐글 예제와 함께 기초 알고리즘부터 최신 기법까지 배우는 ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791158393359, null, '블라드 코노노프 지음 ;오창윤 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.12', null,
+        'https://image.aladin.co.kr/product/29522/75/cover/k462837347_1.jpg',
+        '도메인 주도 설계 첫걸음 :소프트웨어 아키텍처와 비즈니스 전략의 일치를 위한 핵심 패턴, 원칙, 실천법 ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791158393519, null, '지은이: 로렌티우 스필카 ;이대엽', '총류 > 총류 > 전산학', '004.61', null,
+        'https://image.aladin.co.kr/product/30027/83/cover/k132838551_1.jpg',
+        '스프링 시큐리티 인 액션 :보안 기초부터 OAuth 2까지, 스프링 시큐리티를 활용한 안전한 앱 설계와 구현 ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791158393717, null, '이정훈 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.11', null,
+        'https://image.aladin.co.kr/product/30428/26/cover/k332830170_1.jpg',
+        '(24단계 실습으로 정복하는) 쿠버네티스 :헬름, 로키, 프로메테우스 등 현장에서 바로 활용할 수 있는 쿠버네티스 도구 활용법 ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791158393816, null, '황세웅 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.76', null,
+        'https://image.aladin.co.kr/product/30862/11/cover/k962831572_1.jpg',
+        '데이터 분석가가 반드시 알아야 할 모든 것 :파이썬 코드와 캐글 데이터셋으로 실습하는 ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791158393915, null, '크리스찬 클라우젠 지음 ;김성원 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.16', null,
+        'https://image.aladin.co.kr/product/30884/41/cover/k802831380_1.jpg',
+        '파이브 라인스 오브 코드 :다섯 줄 제한 규칙으로 시작하는 체계적이고 효과적인 리팩터링 수련법 ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791158393939, null, '알렉산더 라울 지음 ;김상민 옮김', '총류 > 총류 > 전산학', '004.588', null,
+        'https://image.aladin.co.kr/product/31088/17/cover/k452831838_1.jpg',
+        '클라우드 네이티브 쿠버네티스 :효율적인 클라우드 네이티브 애플리케이션 구축과 운영을 위한 쿠버네티스 모범 사례 ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791158393977, null, '우에노 후미아키,김민호 옮김', '총류 > 총류 > 전산학', '004.588', null,
+        'https://image.aladin.co.kr/product/31034/92/cover/k802831510_1.jpg',
+        '(그림과 작동 원리로 쉽게 이해하는) AWS 구조와 서비스 :AWS의 전체 구조와 기술이 한눈에 들어오는 아마존 웹 서비스 핵심 가이드 ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791158394097, null, '주하 힌쿨라 지음 ;최민석 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.118', null,
+        'https://image.aladin.co.kr/product/31295/59/cover/k452832788_1.jpg',
+        '(실전! 스프링 부트와 리액트로 시작하는) 모던 웹 애플리케이션 개발 :스프링 부트와 리액트를 활용한 실습 중심의 풀스택 웹 애플리케이션 개발 ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791158394196, null, '임지영 지음', '총류 > 총류 > 전산학', '004.5', null,
+        'https://image.aladin.co.kr/product/31544/30/cover/k482832643_1.jpg',
+        '(그림으로 쉽게 이해하는) 웹/HTTP/네트워크 :풍부한 그림과 다양한 예시로 쉽고 재미있게 배우자! ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791158394240, null, '키하시 마사히로 지음 ;김모세 옮김', '총류 > 총류 > 전산학', '004.57', null,
+        'https://image.aladin.co.kr/product/31544/28/cover/k242832643_1.jpg',
+        '(그림과 작동 원리로 쉽게 이해하는) 서버의 기초 :서버의 전체 구조와 기술이 한눈에 들어오는 핵심 입문서 ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791158394332, null, '테지마 타쿠야,김모세 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.118', null,
+        'https://image.aladin.co.kr/product/31732/11/cover/k212833992_1.jpg',
+        '(타입스크립트, 리액트, Next.js로 배우는) 실전 웹 애플리케이션 개발 ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791158394608, null, '김준성,안상준 지음', '총류 > 총류 > 전산학', '004.73', null,
+        'https://image.aladin.co.kr/product/32266/41/cover/k362834843_1.jpg',
+        '진짜 챗GPT API 활용법 :ChatGPT API 기반의 음성 비서부터 카카오톡/텔레그램 챗봇 제작, 랭체인 활용, 파인튜닝까지 ', '위키북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93560, null, 2017, 9791160501728, null, '이승찬 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.1', null,
+        'http://image.aladin.co.kr/product/10927/30/cover/k322531365_1.jpg',
+        '모두의 알고리즘 =컴퓨팅 사고를 위한 기초 알고리즘 /Algorithms for everyone ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2017, 9791160503715, null, '조태호 지음', '총류 > 총류 > 전산학', '004.73', null,
+        'http://image.aladin.co.kr/product/12688/18/cover/k892532177_1.jpg',
+        '모두의 딥러닝 =원리를 쉽게 이해하고 나만의 딥러닝 모델을 만들 수 있다! /Deep learning for everyone ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2018, 9791160505030, null, '미즈구치 카츠야 지음 ;이승룡 옮김', '총류 > 총류 > 전산학', '004.5', null,
+        'https://image.aladin.co.kr/product/15149/12/cover/k812533461_1.jpg',
+        '모두의 네트워크 =10일 만에 배우는 네트워크 기초 /Network for everyone ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2018, 9791160505771, null, '김도연 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.755', null,
+        'https://image.aladin.co.kr/product/16754/81/cover/k442534660_1.jpg',
+        '모두의 SQL =누구나 쉽게 배우는 데이터 분석 기초 /SQL for everyone ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2018, 9791160505856, null, '지은이: 이승찬', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/17281/93/cover/k692534094_1.jpg', '모두의 파이썬 :20일 만에 배우는 프로그래밍 기초 ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2018, 9791160506181, null, '남재윤 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/17329/42/cover/k072534390_1.jpg', '파이썬 코딩 도장 :learn python the right way ',
+        '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2019, 9791160506822, null, '이병승 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.138', null,
+        'https://image.aladin.co.kr/product/17793/15/cover/k522534321_1.jpg',
+        '자바 웹을 다루는 기술 =실무에서 알아야 할 기술은 따로있다! /The art of Java web programing ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2019, 9791160507812, null, '송석리,이현아 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.76', null,
+        'https://image.aladin.co.kr/product/18986/26/cover/k602635687_1.jpg',
+        '모두의 데이터 분석 =실생활 예제로 시작하는 데이터 분석 첫걸음 /Data analysis for everyone ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2019, 9791160508796, null, '김민준 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.118', null,
+        'https://image.aladin.co.kr/product/20481/95/cover/k662635453_1.jpg',
+        '리액트를 다루는 기술 =실무에서 알아야 할 기술은 따로 있다! /The art of React ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791161756271, null, '라파엘 레쉬코 지음 ;이정표 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.1', null,
+        'https://image.aladin.co.kr/product/30002/98/cover/k722838253_1.jpg', '(도커와 젠킨스, 쿠버네티스로 만드는) 배포 자동화와 지속적 인도 ',
+        '에이콘(에이콘출판주식회사)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2018, 9791162240441, null, '와쿠이 요시유키,박광수 옮김', '총류 > 총류 > 전산학', '004.73', null,
+        'http://image.aladin.co.kr/product/13114/7/cover/k062532198_1.jpg',
+        '처음 배우는 딥러닝 수학 :그림으로 이해하고 엑셀로 확인하는 딥러닝 수학 기본 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2018, 9791162241387, null, '지은이: 뉴 사이언티스트,옮긴이: 김정민', '총류 > 총류 > 전산학', '004.73', null,
+        'https://image.aladin.co.kr/product/17530/34/cover/k542534303_1.jpg',
+        '기계는 어떻게 생각하고 학습하는가 :6인의 위대한 AI 석학이 조망하는 인공지능의 현재와 미래 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2019, 9791162241523, null, '지은이: 다케우치 사토루 ;옮긴이: 신준희', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.44', null,
+        'https://image.aladin.co.kr/product/18155/41/cover/k842534140_1.jpg',
+        '실습과 그림으로 배우는 리눅스 구조 :개발자가 알아야 하는 OS와 하드웨어의 기초 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2019, 9791162241745, null, '지은이: 사이토 고키 ;옮긴이: 개앞맵시', '총류 > 총류 > 전산학', '004.73', null,
+        'https://image.aladin.co.kr/product/18964/12/cover/k972635587_1.jpg',
+        '밑바닥부터 시작하는 딥러닝 :파이썬으로 직접 구현하며 배우는 순환 신경망과 자연어 처리', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (94000, null, 2019, 9791162241868, null, '서현우 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/19393/31/cover/k772635210_1.jpg', '혼자 공부하는 C 언어 :1:1 과외하듯 배우는 프로그래밍 자습서 ',
+        '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (94000, null, 2019, 9791162241875, null, '신용권 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/19393/14/cover/k422635210_1.jpg', '혼자 공부하는 자바 :1:1 과외하듯 배우는 프로그래밍 자습서 ',
+        '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (94000, null, 2019, 9791162241882, null, '윤인성 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/19393/14/cover/k432635210_1.jpg', '혼자 공부하는 파이썬 :1:1 과외하듯 배우는 프로그래밍 자습서 ',
+        '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2019, 9791162242025, null, '지은이: 라울-게이브리얼 우르마,옮긴이: 우정은', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133',
+        null, 'https://image.aladin.co.kr/product/20006/92/cover/k042635140_1.jpg',
+        '모던 자바 인 액션 :전문가를 위한 자바 8, 9, 10 기법 가이드 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2020, 9791162242032, null, '정호영,진유림 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.12', null,
+        'https://image.aladin.co.kr/product/22332/32/cover/k712636023_1.jpg',
+        '(팀 개발을 위한) Git, GitHub 시작하기 :소스코드 버전 관리를 위한 깃·깃허브, 오픈소스 참여 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2020, 9791162242513, null, '윤기태 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.76', null,
+        'https://image.aladin.co.kr/product/22964/73/cover/k532637497_1.jpg', '이것이 데이터 분석이다 :파이썬으로 배우는 데이터 분석 입문 ',
+        '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2020, 9791162242780, null, '우재남 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.7533', null,
+        'https://image.aladin.co.kr/product/23868/84/cover/k592639486_1.jpg',
+        '이것이 MySQL이다 :MySQL 설치부터 PHP, 파이썬 연동까지 한번에! ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2020, 9791162242834, null, '오준석 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.11', null,
+        'https://image.aladin.co.kr/product/23205/13/cover/k302637105_1.jpg',
+        '(오준석의) 플러터 생존코딩 :flutter와 dart 입문부터 안드로이드와 iOS용 3가지 앱 개발까지 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2020, 9791162242964, null, '지은이: 오렐리앙 제롱 ;옮긴이: 박해선', '총류 > 총류 > 전산학', '004.73', null,
+        'https://image.aladin.co.kr/product/23767/71/cover/k532639960_1.jpg',
+        '핸즈온 머신러닝 :사이킷런, 케라스, 텐서플로 2를 활용한 머신러닝, 딥러닝 완벽 실무 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (94000, null, 2020, 9791162243039, null, '문현일 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/24315/51/cover/k972630699_1.jpg',
+        '혼자 공부하는 첫 프로그래밍 with 파이썬 :1:1 과외하듯 배우는 왕초보 코딩 입문서 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2020, 9791162243077, null, '나동빈 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/24788/21/cover/k342631735_1.jpg',
+        '이것이 취업을 위한 코딩 테스트다 with 파이썬 :취업과 이직을 결정하는 알고리즘 인터뷰 완벽 가이드 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (94000, null, 2022, 9791162243091, null, '강민철 지음', '총류 > 총류 > 전산학', '004', null,
+        'https://image.aladin.co.kr/product/29901/42/cover/k932838038_1.jpg',
+        '혼자 공부하는 컴퓨터구조 + 운영체제 :1:1 과외하듯 배우는 컴퓨터 공학 전공 지식 자습서 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2020, 9791162243206, null, '김황후 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/24291/49/cover/k272630783_1.jpg',
+        '파이썬 증권 데이터 분석 :파이썬 입문, 웹 스크레이핑, 트레이딩 전략, 자동 매매, 딥러닝을 이용한 주가 예측까지 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2020, 9791162243589, null, '우재남 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.44', null,
+        'https://image.aladin.co.kr/product/25468/47/cover/k862633822_1.jpg',
+        '이것이 우분투 리눅스다 :우분투 리눅스 설치부터 네트워크와 서버 구축, 운영까지 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (94000, null, 2020, 9791162243664, null, '박해선 지음', '총류 > 총류 > 전산학', '004.73', null,
+        'https://image.aladin.co.kr/product/25793/20/cover/k052736813_1.jpg',
+        '혼자 공부하는 머신러닝+딥러닝 :1:1 과외하듯 배우는 프로그래밍 자습서 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (94000, null, 2021, 9791162243671, null, '윤인성 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.138', null,
+        'https://image.aladin.co.kr/product/25858/38/cover/k302737364_1.jpg', '혼자 공부하는 자바스크립트 :1:1 과외하듯 배우는 프로그래밍 자습서 ',
+        '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9791162244166, null, '강남석 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.53', null,
+        'https://image.aladin.co.kr/product/27052/27/cover/k662731384_1.jpg',
+        '일잘러의 비밀, 구글 스프레드시트 제대로 파헤치기 :구글 스프레드시트로 엑셀 밟고 칼퇴하자 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9791162244326, null, '지은이: 마이클 킬링 ;옮긴이: 김영재', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.12', null,
+        'https://image.aladin.co.kr/product/27212/34/cover/k422732298_1.jpg',
+        '개발자에서 아키텍트로 :38가지 팀 활동을 활용한 실전 소프트웨어 아키텍트 훈련법 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (94000, null, 2021, 9791162244739, null, '우재남 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.755', null,
+        'https://image.aladin.co.kr/product/28203/15/cover/k032835973_1.jpg', '혼자 공부하는 SQL :1:1 과외하듯 배우는 데이터베이스 자습서 ',
+        '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9791162244760, null, '클레어 정 지음', '총류 > 총류 > 전산학', '004.78', null,
+        'https://image.aladin.co.kr/product/28225/17/cover/k782835377_1.jpg',
+        '(UX/UI 디자이너를 위한) 실무 피그마 :디자인 시스템에서 개발 전달까지 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9791162244869, null, '지은이: 마크 리처즈,옮긴이: 이일웅', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.12', null,
+        'https://image.aladin.co.kr/product/28176/9/cover/k042835661_1.jpg',
+        '소프트웨어 아키텍처 101 :엔지니어링 접근 방식으로 배우는 소프트웨어 아키텍처 기초 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791162245262, null, '에릭 프리먼,서환수 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.1', null,
+        'https://image.aladin.co.kr/product/29089/24/cover/k212837767_1.jpg',
+        '헤드퍼스트 디자인패턴 :14가지 GoF 필살 패턴! 유지 관리가 편리한 객체지향 소프트웨어를 만드는 법 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791162245316, null, '문준영 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.76', null,
+        'https://image.aladin.co.kr/product/29008/60/cover/k432836421_1.jpg',
+        '(피터의) 고객을 끌어오는 구글 애널리틱스4 :입문부터 최신 고급 기법까지 실무에 필요한 웹 로그 분석 완벽 설명&실습가이드 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791162245385, null, '최범균 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.12', null,
+        'https://image.aladin.co.kr/product/29142/6/cover/k262837077_1.jpg', '도메인 주도 개발 시작하기 :DDD 핵심 개념 정리부터 구현까지 ',
+        '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (94000, null, 2022, 9791162245552, null, '고현민 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.1', null,
+        'https://image.aladin.co.kr/product/29446/54/cover/k362837939_1.jpg',
+        '혼자 공부하는 얄팍한 코딩지식 :비전공자도 1:1 과외하듯 배우는 IT 지식 입문서 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791162245569, null, '포스코인재창조원 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/29318/85/cover/k272837713_1.jpg', '일잘러의 비밀, 엑셀 대신 파이썬으로 업무 자동화하기 ',
+        '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (94000, null, 2022, 9791162245651, null, '윤인성 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/29499/67/cover/k412837047_1.jpg', '혼자 공부하는 파이썬 :1:1 과외하듯 배우는 프로그래밍 자습서 ',
+        '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791162245682, null, '이인제 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.138', null,
+        'https://image.aladin.co.kr/product/29547/4/cover/k982837150_1.jpg', '(소플의) 처음 만난 리액트 :리액트 기초 개념 정리부터 실습까지 ',
+        '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791163034025, null, '고경희,이고잉 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.13', null,
+        'https://image.aladin.co.kr/product/30224/71/cover/k022839205_1.jpg', '(Do it!) 깃&깃허브 입문 :지옥에서 온 문서 관리자 ',
+        '이지스퍼블리싱');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2020, 9791165210885, null, '이호진 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.13', null,
+        'https://image.aladin.co.kr/product/23546/15/cover/k872638022_1.jpg',
+        'Git 교과서 =코드 이력, 하나도 놓치지 마라! /Git textbook ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2020, 9791165212353, null, '서지영 지음', '총류 > 총류 > 전산학', '004.73', null,
+        'https://image.aladin.co.kr/product/24719/52/cover/k542631618_1.jpg',
+        '모두의 인공지능 기초 수학 =누구나 쉽게 시작하는 인공지능 수학 /Basic mathematics for artificial intelligence ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93560, null, 2020, 9791165213183, null, '고재성,이상훈 지음', '총류 > 총류 > 전산학', '004.5', null,
+        'https://image.aladin.co.kr/product/25415/58/cover/k032633114_1.jpg',
+        'IT 엔지니어를 위한 네트워크 입문 =Introduction to networks for IT engineers ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9791165215682, null, '오가사와라 시게타카 지음 ;성창규 옮김', '총류 > 총류 > 전산학', '004.588', null,
+        'https://image.aladin.co.kr/product/27414/31/cover/k222732556_1.jpg',
+        '그림으로 이해하는 AWS 구조와 기술 =The structure and technology of AWS ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9791165215743, null, '조훈,문성주 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.1', null,
+        'https://image.aladin.co.kr/product/27311/12/cover/k462732121_1.jpg', '(컨테이너 인프라 환경 구축을 위한) 쿠버네티스/도커 ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9791165215965, null, '안지혜 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/27435/94/cover/k552733375_1.jpg',
+        '(Let''s get IT) 파이썬 프로그래밍 =데이터 분석 프로젝트로 프로그래밍 사고력 기르기 /Let''s get IT Python ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9791165216283, null, '마사야 아오야마 지음 ;박상욱 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.11', null,
+        'https://image.aladin.co.kr/product/27618/96/cover/k182733121_1.jpg', '쿠버네티스 완벽 가이드 ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9791165216863, null, '사이토 마사노리 지음 ;김성훈 옮김', '총류 > 총류 > 전산학', '004', null,
+        'https://image.aladin.co.kr/product/27965/5/cover/k012734312_1.jpg',
+        '그림으로 이해하는 IT 지식과 트렌드 :디지털 시대에 알맞은 필수 IT 교양서 ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9791165217167, null, '박준성 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/28095/52/cover/k722734341_1.jpg',
+        '(쉽게 따라 만드는) 파이썬 주식 자동매매 시스템 =Python auto trading system ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9791165218157, null, '미야케 히데아키,이동규 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.44', null,
+        'https://image.aladin.co.kr/product/28536/86/cover/k742835137_1.jpg',
+        '모두의 리눅스 =누구나 쉽게 시작하는 리눅스 기초 /Linux for everyone ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791165218942, null, '서지영 지음', '총류 > 총류 > 전산학', '004.73', null,
+        'https://image.aladin.co.kr/product/28966/10/cover/k262836721_1.jpg',
+        '딥러닝 파이토치 교과서 =Deep learning with pytorch ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791165219154, null, '기타하라 요시노리 지음 ;조태호 옮김', '총류 > 총류 > 전산학', '004.73', null,
+        'https://image.aladin.co.kr/product/29109/76/cover/k782837261_1.jpg',
+        '그림으로 이해하는 인지과학 :인간은 정보를 어떻게 이해하고 처리하는가? ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791165219246, null, '조태호 지음', '총류 > 총류 > 전산학', '004.73', null,
+        'https://image.aladin.co.kr/product/29169/46/cover/k662837474_1.jpg',
+        '모두의 딥러닝 =누구나 쉽게 이해하는 딥러닝 /Deep learning for everyone ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791165219468, null, '김기수 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.118', null,
+        'https://image.aladin.co.kr/product/29234/10/cover/k292837292_1.jpg',
+        '코딩 자율학습 HTML + CSS + 자바스크립트 =기초부터 반응형 웹까지 초보자를 위한 웹 개발 입문서 /Self-study coding HTML + CSS + Javascript ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791165219529, null, '주홍철 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.138', null,
+        'https://image.aladin.co.kr/product/29281/57/cover/k382837902_1.jpg',
+        '(면접을 위한) CS 전공지식 노트 =Computer science note ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791165219659, null, '기타미 류지 지음 ;성창규 옮김', '총류 > 총류 > 전산학', '004.5', null,
+        'https://image.aladin.co.kr/product/29327/73/cover/k232837815_1.jpg', '그림으로 이해하는 네트워크 용어 ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791165219895, null, '오키타 토시야 지음 ;김성훈 옮김', '총류 > 총류 > 전산학', '004.5', null,
+        'https://image.aladin.co.kr/product/29533/68/cover/k162837855_2.jpg', '(한 권으로 끝내는) 네트워크 기초 :클라우드 시대의 네트워크 입문서 ',
+        '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9791165920548, null, '최원영 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.74', null,
+        'https://image.aladin.co.kr/product/26898/58/cover/k562730509_1.jpg',
+        '아파치 카프카 애플리케이션 프로그래밍 :카프카의 개념부터 스트림즈·커넥트·스프링 카프카까지 데이터 파이프라인 구축 따라하기 ', 'BJpublic(비제이퍼블릭)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9791165920739, null, '김동주 지음', '총류 > 총류 > 전산학', '004.78', null,
+        'https://image.aladin.co.kr/product/27503/55/cover/k222733096_1.jpg',
+        '(웹 디자인 & 웹 퍼블리싱을 위한) 피그마 완벽 활용서 :웹 트렌드를 반영한 반응형 쇼핑몰 따라 만들기 ', 'BJpublic(비제이퍼블릭)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9791165921057, null, '이재성,한정 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.118', null,
+        'https://image.aladin.co.kr/product/28376/93/cover/k852835600_1.jpg',
+        '기초부터 완성까지, 프런트엔드 :개발부터 테스트까지, 이론과 예제로 배우는 프런트엔드 ', 'BJpublic(비제이퍼블릭)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791165921514, null, '권태형 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.58', null,
+        'https://image.aladin.co.kr/product/29327/97/cover/k712837815_1.jpg',
+        '쉽고 빠른 플러터 앱 개발 :flutter & dart로 화면 구현·상태 관리·데이터 처리·디자인 패턴 익히기 ', 'BJpublic(비제이퍼블릭)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791165921767, null, '옥정헌 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.563', null,
+        'https://image.aladin.co.kr/product/30921/70/cover/k132831291_1.jpg',
+        '(아이패드로 시작하는) 음악 프로듀싱 with 개러지밴드 :비트메이킹 등 실습 예제 파일과 단계별 학습 가이드 제공 ', 'BJpublic(비제이퍼블릭)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791165921781, null, '지은이: 최규민', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.118', null,
+        'https://image.aladin.co.kr/product/30636/69/cover/k942830927_1.jpg',
+        '나 혼자 만든다! 영화 추천 웹 서비스로 배우는 풀스택 :#풀스택#영화추천서비스#프로젝트#스타트업 ', 'BJpublic(비제이퍼블릭)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791165922146, null, '지은이: 곽경일', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/31754/63/cover/k572833004_1.jpg',
+        '인공지능, 주식투자 좀 부탁해 :입문자를 위한 파이썬 주식 예측 자동 매매 프로그램 만들기 ', '비제이퍼블릭');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791169210027, null, '신용권,임경균 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/30034/9/cover/k192839167_1.jpg',
+        '이것이 자바다 :교육 현장에서 가장 많이 쓰이는 JAVA 프로그래밍의 기본서 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791169210126, null, '지은이: 로런스 모로니 ;옮긴이: 박해선', '총류 > 총류 > 전산학', '004.73', null,
+        'https://image.aladin.co.kr/product/29989/91/cover/k072838056_1.jpg',
+        '개발자를 위한 머신러닝&딥러닝 :인공지능 개발자로 레벨 업하기! 신경망 기초부터 컴퓨터 비전, 자연어 처리, 시계열 예측까지 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (94000, null, 2023, 9791169210287, null, '지은이: 박해선 ;박해선', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.76', null,
+        'https://image.aladin.co.kr/product/30707/1/cover/k602830144_1.jpg', '혼자 공부하는 데이터 분석 :1:1 과외하듯 배우는 데이터 분석 자습서 ',
+        '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791169210317, null, '김유지 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/30188/15/cover/k202839995_1.jpg',
+        '어쩌다 데이터 분석 with 파이썬 :판다스로 시작하는 효율적인 데이터 분석 및 시각화 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791169210461, null, '클레어 정 지음', '총류 > 총류 > 전산학', '004.78', null,
+        'https://image.aladin.co.kr/product/30394/19/cover/k832830168_1.jpg',
+        '(UX/UI 디자이너를 위한) 실무 피그마 :디자인 시스템에서 개발 전달까지 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791169210508, null, '지은이: 루이스 턴스톨,옮긴이: 박해선', '총류 > 총류 > 전산학', '004.735', null,
+        'https://image.aladin.co.kr/product/30572/23/cover/k122830711_1.jpg',
+        '트랜스포머를 활용한 자연어 처리 :허깅페이스 개발팀이 알려주는 자연어 애플리케이션 구축 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791169210713, null, '미셸 리바 지음 ;박수현 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.138', null,
+        'https://image.aladin.co.kr/product/30844/87/cover/k382831471_1.jpg',
+        '실전에서 바로 쓰는 Next.js :SSR부터 SEO, 배포까지 확장성 높은 풀스택 서비스 구축 가이드 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791169210737, null, '김용욱 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.12', null,
+        'https://image.aladin.co.kr/product/31004/40/cover/k052831216_1.jpg',
+        '마이크로서비스 아키텍처 구축 가이드 :성공적인 마이크로서비스 아키텍처 적용을 위한 체크포인트와 전략 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791169210850, null, '지은이: 칩 후옌 ;김영민', '총류 > 총류 > 전산학', '004.73', null,
+        'https://image.aladin.co.kr/product/31281/61/cover/k622832473_1.jpg',
+        '머신러닝 시스템 설계 :프로젝트 범위 산정부터 프로덕션 배포 후 모니터링까지, MLOps 완벽 해부하기 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791169210874, null, '압둘라지즈 압둘라지즈 아데시나 지음 ;김완섭 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133',
+        null, 'https://image.aladin.co.kr/product/31268/75/cover/k422832465_1.jpg',
+        'FastAPI를 사용한 파이썬 웹 개발 :라우팅 기초부터 이벤트 플래너 애플리케이션 구축 및 배포까지 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791169210881, null, '자레드 바티,하성창 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.12', null,
+        'https://image.aladin.co.kr/product/31438/52/cover/k722832318_1.jpg',
+        'Docs for developers :개발 생태계 모든 사람을 위한 기술 문서 작성 방법 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791169211048, null, '이안 클레이턴 지음 ;김상규 옮김', '총류 > 총류 > 전산학', '004.73', null,
+        'https://image.aladin.co.kr/product/31581/13/cover/k132833862_1.jpg',
+        '직장인을 위한 챗GPT :업무 스킬업부터 자기 계발까지! 694개 ChatGPT 파워 프롬프트 가이드 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791169211079, null, '지은이: 박해선 ;일러스트: 이진숙', '총류 > 총류 > 전산학', '004.73', null,
+        'https://image.aladin.co.kr/product/31892/0/cover/k202833636_1.jpg',
+        '(인공지능 전문가가 알려 주는) 챗GPT로 대화하는 기술 :딥러닝 개념부터 프롬프트 작성, bing AI, 이미지 생성까지 ', '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791169211239, null, '최범균 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.1', null,
+        'https://image.aladin.co.kr/product/32057/59/cover/k572834799_1.jpg', '육각형 개발자 :시니어 개발자로 성장하기 위한 10가지 핵심 역량 ',
+        '한빛미디어');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2015, 9791185890265, null, '야마자키 야스시,김완섭 옮김', '총류 > 총류 > 전산학', '004.2', null,
+        'http://image.aladin.co.kr/product/6275/40/cover/k862433736_1.jpg', '(그림으로 공부하는) IT 인프라 구조 =IT infrastructure ',
+        'Jpub(제이펍)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2016, 9791185890678, null, '리브로웍스 지음 ;신상재 옮김', '총류 > 총류 > 전산학', '004.52', null,
+        'https://bookthumb-phinf.pstatic.net/cover/110/544/11054407.jpg?type=m1&udate=20160913',
+        '(명쾌한 설명과 풍부한 그림으로 배우는) TCPIP 쉽게, 더 쉽게 ', 'Jpub(제이펍)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2017, 9791186697474, null, '민형기 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'http://image.aladin.co.kr/product/12609/37/cover/k372532974_1.jpg',
+        '파이썬으로 데이터 주무르기 :독특한 예제를 통해 배우는 데이터 분석 입문 ', 'BJpublic(비제이퍼블릭)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791186710753, null, '김성연 지음', '총류 > 총류 > 전산학', '004.78', null,
+        'https://image.aladin.co.kr/product/28530/4/cover/k952835034_1.jpg',
+        '사용자를 사로잡는 UX/UI 실전가이드 =시장에서 살아남는 화면 설계와 스마트한 데이터 활용법, 현실적인 브랜딩과 디자인 윤리까지 /UX/UI_design practical_guide that take_user_by_storm ',
+        '루비페이퍼');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791186710982, null, '지은이: 김수환', '총류 > 총류 > 전산학', '004.76', null,
+        'https://image.aladin.co.kr/product/31355/91/cover/k952832098_1.jpg',
+        '(이토록 쉬운) 까망고니의 블렌더 트레이닝 :블렌더를 배우는 가장 완벽한 기초 ', '루비페이퍼');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93560, null, 2016, 9791186978894, null, '이승찬 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'http://image.aladin.co.kr/product/8265/87/cover/k492434159_1.jpg',
+        '모두의 파이썬 =20일 만에 배우는 프로그래밍 기초 /Python for everyone ', '길벗');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2018, 9791188621125, null, '이시다 모리테루,김완섭 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.1', null,
+        'http://image.aladin.co.kr/product/13262/84/cover/k552532694_1.jpg',
+        '알고리즘 도감 :그림으로 배우는 알고리즘 26 =Algorithms: explanined & animated ', 'Jpub(제이펍)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2018, 9791189184018, null, '지은이: 구멍가게 코딩단', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.118', null,
+        'https://bookthumb-phinf.pstatic.net/cover/139/937/13993776.jpg?type=m1&udate=20180907',
+        '(코드로 배우는) 스프링 웹 프로젝트 :현업 개발을 위한 단계별 실습서 ', '남가람북스');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2020, 9791189909178, null, '박상길 지음 ;정진호 일러스트', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.1', null,
+        'https://image.aladin.co.kr/product/24549/58/cover/k822631873_1.jpg',
+        '파이썬 알고리즘 인터뷰 :95가지 알고리즘 문제 풀이로 완성하는 코딩 테스트 ', '책만');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9791189909284, null, '조너선 스타인하트 지음 ;오현석 옮김', '총류 > 총류 > 전산학', '004.22', null,
+        'https://image.aladin.co.kr/product/26844/45/cover/k942730395_1.jpg',
+        '(한 권으로 읽는) 컴퓨터 구조와 프로그래밍 :더 나은 소프트웨어 개발을 위한 하드웨어, 자료구조, 필수 알고리즘 등 프로그래머의 비밀 노트 ', '책만');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9791189909307, null, '그렉 턴키스트 지음 ;오명운 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.118', null,
+        'https://image.aladin.co.kr/product/27182/44/cover/k292731352_1.jpg',
+        '스프링 부트 실전 활용 마스터 :spring boot ver 2.4 대응 ', '책만');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791189909529, null, '크리스 리코미니,장현희 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.104', null,
+        'https://image.aladin.co.kr/product/31725/28/cover/k052833894_1.jpg',
+        '필독! 개발자 온보딩 가이드 :지속 가능한 소프트웨어와 원활한 협업 문화를 이해하는 프로페셔널 개발자의 탄생 ', '책만');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2019, 9791190014281, null, '박준규 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/18957/44/cover/k432635487_1.jpg',
+        '퀀트 전략 파이썬으로 세워라 =누구나 시작할 수 있는 파이썬 퀀트 투자 첫 단추 /Quant strategy with python ', 'BJpublic(비제이퍼블릭)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93500, null, 2019, 9791190314008, null, '앨런 튜링 지음 ;곽재식 해제', '총류 > 총류 > 전산학', '004.73', null,
+        'https://image.aladin.co.kr/product/19832/25/cover/k522636989_1.jpg',
+        '앨런 튜링 지능에 관하여 =Seminal writings on artificial intelligence ', 'HB Press(에이치비 프레스)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2020, 9791190665209, null, '야마자키 야스시,김완섭 옮김', '총류 > 총류 > 전산학', '004.2', null,
+        'https://image.aladin.co.kr/product/25711/43/cover/k642736774_1.jpg',
+        '(그림으로 공부하는) IT 인프라 구조 =IT infrastructure ', 'Jpub(제이펍)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9791191600414, null, '미야타 히로시 지음 ;김모세 옮김', '총류 > 총류 > 전산학', '004.52', null,
+        'https://image.aladin.co.kr/product/28130/60/cover/k592734253_1.jpg', '(그림으로 공부하는) TCP/IP 구조 ', 'Jpub(제이펍)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791191600650, null, '펠리너 헤르만스 지음 ;차건회 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.1', null,
+        'https://image.aladin.co.kr/product/28596/70/cover/k832835755_1.jpg', '프로그래머의 뇌 :훌륭한 프로그래머가 알아야 할 인지과학의 모든 것 ',
+        'Jpup(제이펍)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791191600759, null, '에릭 노먼드 지음 ;김은민 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/29234/92/cover/k682837293_1.jpg',
+        '(쏙쏙 들어오는) 함수형 코딩 :심플한 코드로 복잡한 소프트웨어 길들이기 ', 'Jpub(제이펍)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791191600896, null, '톰 롱 지음 ;차건회 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.1', null,
+        'https://image.aladin.co.kr/product/29464/92/cover/k422837236_1.jpg',
+        '좋은 코드, 나쁜 코드 =프로그래머의 코드 품질 개선법 /Good code, bad code ', 'Jpub(제이펍)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791191600988, null, '다루사와 히로유키,김완섭 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.12', null,
+        'https://image.aladin.co.kr/product/29860/40/cover/k282838129_1.jpg', '(그림으로 공부하는) 마이크로서비스 구조 ', 'Jpub(제이펍)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9791191905014, null, '지은이: 박미정', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.12', null,
+        'https://image.aladin.co.kr/product/27890/27/cover/k392734204_1.jpg', '(박미정의) 깃&깃허브 입문 ',
+        'Golden Rabbit(골든래빗)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791191905076, null, '지은이: 신백균', '총류 > 총류 > 전산학', '004.73', null,
+        'https://image.aladin.co.kr/product/29251/4/cover/k332837394_1.jpg',
+        '머신러닝·딥러닝 문제해결 전략 :캐글 수상작 리팩터링으로 배우는 문제해결 프로세스와 전략 ', 'Golden Rabbit(골든래빗)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791191905090, null, '지은이: 홍정아', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.58', null,
+        'https://image.aladin.co.kr/product/28833/91/cover/k892836692_1.jpg', '(Joyce의) 안드로이드 앱 프로그래밍 with 코틀린 ',
+        'Golden Rabbit(골든래빗)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791191905113, null, '박종천 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.104', null,
+        'https://image.aladin.co.kr/product/28501/32/cover/k572835625_1.jpg',
+        '개발자로 살아남기 :한글과컴퓨터, 블리자드, 넥슨, 삼성전자, 몰로코 출신 개발자의 30년 커리어패스 인사이트 ', 'Golden Rabbit(골든래빗)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791191905199, null, '지은이: 권영재,주은진', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.118', null,
+        'https://image.aladin.co.kr/product/29287/16/cover/k862837005_1.jpg',
+        '코로나보드로 배우는 실전 웹 서비스 개발 :Node.js와 AWS를 활용한 설계부터 크롤링, 개발, 운영, 수익화까지 ', 'Golden Rabbit(골든래빗)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791191905236, null, '박성철,장동수 공저', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.104', null,
+        'https://image.aladin.co.kr/product/30618/27/cover/k542830726_1.jpg',
+        '개발자 원칙 =테크 리더 9인이 말하는 더 나은 개발자로 살아가는 원칙과 철학 /Developer principle ', 'Golden Rabbit(골든래빗)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791191905250, null, '지은이: 최지호', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.58', null,
+        'https://image.aladin.co.kr/product/30708/52/cover/k632830147_1.jpg',
+        '코드팩토리의 플러터 프로그래밍 :Dart & Flutter 입문부터 실전에 유용한 10가지 앱 개발과 광고와 배포까지 ', 'Golden rabbit(골든래빗)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791191905274, null, '지은이: 박승규', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.138', null,
+        'https://image.aladin.co.kr/product/31477/49/cover/k302832529_1.jpg',
+        'Node.js 백엔드 개발자 되기 :Typescript+Node.js+Express+NestJS로 배우는 자바스크립트 백엔드 입문자를 위한 풀 패키지 ', 'Golden Rabbit(골든래빗)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791191905298, null, '지은이: 신선영', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.138', null,
+        'https://image.aladin.co.kr/product/31574/25/cover/k512833768_1.jpg',
+        '스프링 부트 3 백엔드 개발자 되기 :백엔드 로드맵에서 엄선한 최신 테크 트리로 탄탄히 배우기', 'Golden Rabbit(골든래빗)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791191905458, null, '우아한형제들 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/32492/9/cover/k392935609_1.jpg',
+        '요즘 우아한 개발 :배달의민족을 만든 우아한형제들의 조직문화, 온보딩, 기획, 개발, 인프라 구축 이야기 ', 'Golden Rabbit(골든래빗)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791192143378, null, '조엘 마시 지음 ;김은지 옮김', '총류 > 총류 > 전산학', '004.78', null,
+        'https://image.aladin.co.kr/product/29943/78/cover/k462838634_1.jpg', '하루 5분 UX :UX/UI 디자인 실무를 위한 100가지 레슨 ',
+        '유엑스 리뷰');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791192469195, null, '구지라 히코즈쿠에 지음 ;문지현 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.133', null,
+        'https://image.aladin.co.kr/product/29745/58/cover/k542838694_1.jpg',
+        '파이썬 자동화 교과서 :업무 생산성을 3배 높이는 엑셀, 워드, 크롤링, 메일 자동화 기술 ', 'Jpub(제이펍)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791192469263, null, 'Studio Shin 지음 ;윤준 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.11', null,
+        'https://image.aladin.co.kr/product/30154/21/cover/k322839487_1.jpg',
+        '(누구나 할 수 있는) 유니티 2D 게임 제작 :초보자도 유니티 2D 게임을 만들 수 있다! 오늘부터 나도 게임 제작자 ', 'Jpub(제이펍)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2022, 9791192469560, null, '한용재 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.11', null,
+        'https://image.aladin.co.kr/product/30619/19/cover/k322830828_1.jpg',
+        'NestJS로 배우는 백엔드 프로그래밍 :타입스크립트 환경의 차세대 서버 프레임워크를 만나다 ', 'Jpub(제이펍)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791192987101, null, '왕정 지음 ;김진호 옮김', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.1', null,
+        'https://image.aladin.co.kr/product/31659/34/cover/k722833679_1.jpg',
+        '디자인 패턴의 아름다움 :객체지향 패러다임부터 설계 원칙, 코딩 규칙, 리팩터링 기법, 디자인 패턴까지 ', 'Jpub(제이펍)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2018, 9791196395704, null, '지은이: 조시형', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.755', null,
+        'http://image.aladin.co.kr/product/14823/37/cover/k892532350_1.jpg', '친절한 SQL 튜닝 :개발자를 위한 SQL 튜닝 입문서 ', '디비안');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2021, 9791197149849, null, '지은이: 임효성', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.13', null,
+        'https://image.aladin.co.kr/product/27271/36/cover/k482732110_1.jpg',
+        '(비전공자를 위한) 첫 코딩 챌린지 :HTML, CSS 입문부터 영상 서비스 앱 UI 만들기와 배포까지 ', 'Golden Rabbit(골든래빗)');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (94000, null, 2022, 9791197641718, null, '박영웅 지음', '총류 > 총류 > 프로그래밍, 프로그램, 데이터', '005.118', null,
+        'https://image.aladin.co.kr/product/28875/99/cover/k572836304_1.jpg', '프론트엔드 개발을 시작하려고 해', '데이원컴퍼니');
+insert into book (addition_symbol, publication_date, publication_year, isbn, approval_status, authors, class_name,
+                  class_no, description, image_url, name, publisher)
+values (93000, null, 2023, 9791198140852, null, '주한나 지음', '총류 > 총류 > 전산학', '004.73', null,
+        'https://image.aladin.co.kr/product/32158/72/cover/k242834410_1.jpg',
+        '챗GPT 개발자 핸드북 :마이크로소프트 AI 개발자가 알려주는 GPT 활용 노하우 ', '한빛미디어');

--- a/src/test/resources/book_trade.sql
+++ b/src/test/resources/book_trade.sql
@@ -1,0 +1,40 @@
+insert into book_trade (latitude, longitude, rental_cost, borough_id, create_date, isbn, limited_date, trade_id,
+                        update_date, user_id, content, delete_yn, trade_type, trade_yn)
+values (37.49805400, 127.02872700, 100000, 1, '2024-05-11 17:47:48', 9791191600414, '2024-05-14 17:48:05', 1,
+        '2024-05-11 17:48:19', 1, '책 빌려드립니다~', 'N', 'BORROW', 'N');
+insert into book_trade (latitude, longitude, rental_cost, borough_id, create_date, isbn, limited_date, trade_id,
+                        update_date, user_id, content, delete_yn, trade_type, trade_yn)
+values (37.49805400, 127.02872700, 120000, 1, '2024-05-11 17:49:21', 9791191905076, '2024-05-16 17:49:33', 2,
+        '2024-05-11 17:49:39', 1, '책 빌려줘~', 'N', 'RENT', 'N');
+insert into book_trade (latitude, longitude, rental_cost, borough_id, create_date, isbn, limited_date, trade_id,
+                        update_date, user_id, content, delete_yn, trade_type, trade_yn)
+values (37.49805400, 127.02872700, 100000, 1, '2024-05-11 17:47:48', 9791191600414, '2024-05-14 17:48:05', 3,
+        '2024-05-11 17:48:19', 1, '책 빌려드립니다~', 'N', 'BORROW', 'N');
+insert into book_trade (latitude, longitude, rental_cost, borough_id, create_date, isbn, limited_date, trade_id,
+                        update_date, user_id, content, delete_yn, trade_type, trade_yn)
+values (37.49805400, 127.02872700, 120000, 1, '2024-05-11 17:49:21', 9791191905076, '2024-05-16 17:49:33', 4,
+        '2024-05-11 17:49:39', 1, '책 빌려줘~', 'N', 'RENT', 'N');
+insert into book_trade (latitude, longitude, rental_cost, borough_id, create_date, isbn, limited_date, trade_id,
+                        update_date, user_id, content, delete_yn, trade_type, trade_yn)
+values (37.49805400, 127.02872700, 100000, 1, '2024-05-11 17:47:48', 9791191600414, '2024-05-14 17:48:05', 5,
+        '2024-05-11 17:48:19', 1, '책 빌려드립니다~', 'N', 'BORROW', 'N');
+insert into book_trade (latitude, longitude, rental_cost, borough_id, create_date, isbn, limited_date, trade_id,
+                        update_date, user_id, content, delete_yn, trade_type, trade_yn)
+values (37.49805400, 127.02872700, 120000, 1, '2024-05-11 17:49:21', 9791191905076, '2024-05-16 17:49:33', 6,
+        '2024-05-11 17:49:39', 1, '책 빌려줘~', 'N', 'RENT', 'N');
+insert into book_trade (latitude, longitude, rental_cost, borough_id, create_date, isbn, limited_date, trade_id,
+                        update_date, user_id, content, delete_yn, trade_type, trade_yn)
+values (37.49805400, 127.02872700, 100000, 1, '2024-05-11 17:47:48', 9791191600414, '2024-05-14 17:48:05', 7,
+        '2024-05-11 17:48:19', 1, '책 빌려드립니다~', 'N', 'BORROW', 'N');
+insert into book_trade (latitude, longitude, rental_cost, borough_id, create_date, isbn, limited_date, trade_id,
+                        update_date, user_id, content, delete_yn, trade_type, trade_yn)
+values (37.49805400, 127.02872700, 120000, 1, '2024-05-11 17:49:21', 9791191905076, '2024-05-16 17:49:33', 8,
+        '2024-05-11 17:49:39', 1, '책 빌려줘~', 'N', 'RENT', 'N');
+insert into book_trade (latitude, longitude, rental_cost, borough_id, create_date, isbn, limited_date, trade_id,
+                        update_date, user_id, content, delete_yn, trade_type, trade_yn)
+values (37.49805400, 127.02872700, 100000, 1, '2024-05-11 17:47:48', 9791191600414, '2024-05-14 17:48:05', 9,
+        '2024-05-11 17:48:19', 1, '책 빌려드립니다~', 'N', 'BORROW', 'N');
+insert into book_trade (latitude, longitude, rental_cost, borough_id, create_date, isbn, limited_date, trade_id,
+                        update_date, user_id, content, delete_yn, trade_type, trade_yn)
+values (37.49805400, 127.02872700, 120000, 1, '2024-05-11 17:49:21', 9791191905076, '2024-05-16 17:49:33', 10,
+        '2024-05-11 17:49:39', 1, '책 빌려줘~', 'N', 'RENT', 'N');

--- a/src/test/resources/borough.sql
+++ b/src/test/resources/borough.sql
@@ -1,0 +1,50 @@
+insert into borough (borough_id, name)
+values (1, '강남구');
+insert into borough (borough_id, name)
+values (2, '강동구');
+insert into borough (borough_id, name)
+values (3, '강북구');
+insert into borough (borough_id, name)
+values (4, '강서구');
+insert into borough (borough_id, name)
+values (5, '관악구');
+insert into borough (borough_id, name)
+values (6, '광진구');
+insert into borough (borough_id, name)
+values (7, '구로구');
+insert into borough (borough_id, name)
+values (8, '금천구');
+insert into borough (borough_id, name)
+values (9, '노원구');
+insert into borough (borough_id, name)
+values (10, '도봉구');
+insert into borough (borough_id, name)
+values (11, '동대문구');
+insert into borough (borough_id, name)
+values (12, '동작구');
+insert into borough (borough_id, name)
+values (13, '마포구');
+insert into borough (borough_id, name)
+values (14, '서대문구');
+insert into borough (borough_id, name)
+values (15, '서초구');
+insert into borough (borough_id, name)
+values (16, '성동구');
+insert into borough (borough_id, name)
+values (17, '성북구');
+insert into borough (borough_id, name)
+values (18, '송파구');
+insert into borough (borough_id, name)
+values (19, '양천구');
+insert into borough (borough_id, name)
+values (20, '영등포구');
+insert into borough (borough_id, name)
+values (21, '용산구');
+insert into borough (borough_id, name)
+values (22, '은평구');
+insert into borough (borough_id, name)
+values (23, '종로구');
+insert into borough (borough_id, name)
+values (24, '중구');
+insert into borough (borough_id, name)
+values (25, '중랑구');

--- a/src/test/resources/user.sql
+++ b/src/test/resources/user.sql
@@ -1,0 +1,3 @@
+insert into user (create_date, user_id, address, email, nickname, password, phone, social_id, role)
+values ('2024-05-11', 1, '서울 관악구 신림동 122-25', 'jinho4744@naver.com', '고소하게',
+        '$2a$10$YAIWGaMMhACl9QhBn4bJqesIkGXFfSfg4yfdcQIB85dkrgo3uatXa', '01012345678', null, 'ROLE_ADMIN');


### PR DESCRIPTION
# Test용 Sql 파일 추가
- 실수로 test에 있던 데이터들 날려버림.....

# List BookTrade API 테스트 추가 및 리팩토링
- 테스트 코드 추가
- RequestDto → Entity → ResponseDto 형태로 수정
  - BookTradeRequestDto(이전 BookTradeDto) → BookTrade(Entity) → BookTradeResponseDto(이전 BookTrade Entity)
    - Response로 BookTrade를 그대로 뿌려주는 것 대신 ResponseDto로 변환해서 뿌려주는 것이 더 좋다고 봄 
    - BookTrade에는 Book과 User도 있는데 이것들도 같이 그대로 뿌려주기 때문, 특히 User에는 Password도 있어 보안상 민감함
    - Response Body json은 API Docs참고 (Repo 메인화면의 README.md)
      - User나 Borough key가 하나만 있으면 그냥 writer/nickname/boroughName등 하나로 해도 되지않나? → 프론트 보니 이미 user.nickname, borough.name되어 있어서 이렇게함 
        - 수정 필요하면 BookTradeResponseDto에서 필드들 수정하면 됨!
        - createdDate는 바로 "yyyy-MM-dd"형식으로 뿌려주도록 변경 → 프론트쪽도 `new Date(trade.createdDate)` 이후 포맷팅 하는 과정 없이 바로 `trade.createdDate`를 렌더링하도록 변경

# Get BookTrade API 테스트 추가 및 리팩토링
- 테스트 코드 추가
- RequestDto → Entity → ResponseDto 형태로 수정
  - Get BookTrade API와 List BookTrade API의 Response Body json이 조금 다르기 때문에 BookTrade[Detail/List]ResponseDto로 수정
  - 마찬가지로 Response Body로 받아야하는 json 데이터의 수정이 필요하다면 BookTradeResponseDto수정하면 됨
  - 마찬가지로 createdDate를 "yyyy-MM-dd"형식으로 뿌려주도록 변경

# Issue
- Read Detail, Create, Update, Delete도 리팩토링 예정
- TradeType에 BORROW/RENT → BORROW/LEND로 하는게 어떤지?
  -  파파고 검색해보니 빌리다 → borrow / 빌려주다 → lend로 나와서..
- Get BookTrade API에서 Id에 해당하는 튜플의 deleteYn이 Y인경우 ResourceNotFound(404 Not Found)를 반환하는데 400/403이 어떤지?
  - 404는 DB에 없다는 얘기인데 DB에는 있는데 deleteYn이 Y라서 "데이터가 없다" 보다는 일반 사용자들은 조회할 수 없다는게 더 맞아 보임
  - 400은 Bad Request / 403은 Forbidden
    - 일반 사용자는 볼 수 없고, 관리자만 볼 수 있으니 권한 관련인 403이 더 맞는거 같기도..?  