### PR TITLE
JH-82: JWT 로직 추가

### DIFF
--- a/src/main/java/com/kh/bookfinder/auth/config/SecurityConfig.java
+++ b/src/main/java/com/kh/bookfinder/auth/config/SecurityConfig.java
@@ -1,6 +1,9 @@
 package com.kh.bookfinder.auth.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kh.bookfinder.auth.jwt.filter.JwtAuthenticationFilter;
+import com.kh.bookfinder.auth.jwt.handler.JwtForbiddenHandler;
+import com.kh.bookfinder.auth.jwt.handler.JwtUnauthorizedHandler;
 import com.kh.bookfinder.auth.jwt.service.JwtService;
 import com.kh.bookfinder.auth.login.filter.JsonLoginFilter;
 import com.kh.bookfinder.auth.login.handler.JsonLoginFailureHandler;
@@ -29,6 +32,8 @@ public class SecurityConfig {
 
   private final JwtService jwtService;
   private final SecurityUserService securityUserService;
+  private final JwtUnauthorizedHandler jwtUnauthorizedHandler;
+  private final JwtForbiddenHandler jwtForbiddenHandler;
   private final ObjectMapper objectMapper;
   private final Validator validator;
 
@@ -46,9 +51,16 @@ public class SecurityConfig {
         .sessionManagement(sessionManagementConfigurer -> sessionManagementConfigurer
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS))
         .authorizeHttpRequests(authorize -> authorize
-            .anyRequest().permitAll())
-        .addFilterAfter(jsonLoginFilter(), LogoutFilter.class);
-
+            .requestMatchers("/api/v1/login", "/api/v1/signup/**").anonymous())
+        .authorizeHttpRequests(authorize -> authorize
+            .requestMatchers("/api/v1/books/list", "/api/v1/books/{isbn}").permitAll())
+        .authorizeHttpRequests(authorize -> authorize
+            .requestMatchers("/api/v1/trades/**").authenticated());
+    httpSecurity.addFilterAfter(jsonLoginFilter(), LogoutFilter.class);
+    httpSecurity.addFilterBefore(jwtAuthenticationFilter(), JsonLoginFilter.class)
+        .exceptionHandling(handler -> handler
+            .authenticationEntryPoint(jwtUnauthorizedHandler)
+            .accessDeniedHandler(jwtForbiddenHandler));
     return httpSecurity.build();
   }
 
@@ -77,5 +89,10 @@ public class SecurityConfig {
     jsonLoginFilter.setAuthenticationSuccessHandler(loginSuccessHandler());
     jsonLoginFilter.setAuthenticationFailureHandler(loginFailureHandler());
     return jsonLoginFilter;
+  }
+
+  @Bean
+  public JwtAuthenticationFilter jwtAuthenticationFilter() {
+    return new JwtAuthenticationFilter(jwtService);
   }
 }

--- a/src/main/java/com/kh/bookfinder/auth/jwt/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/kh/bookfinder/auth/jwt/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,55 @@
+package com.kh.bookfinder.auth.jwt.filter;
+
+import com.kh.bookfinder.auth.jwt.service.JwtService;
+import com.kh.bookfinder.auth.login.dto.SecurityUserDetails;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.util.AntPathMatcher;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+@RequiredArgsConstructor
+@Slf4j
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+  private static final String LOGIN_URL = "/api/v1/login";
+  private static final List<String> EXCEPT_FILTER_URLS =
+      List.of("/api/v1/signup/**", "/api/v1/books/list", "/api/v1/books/{isbn}");
+  private final JwtService jwtService;
+  private final AntPathMatcher antPathMatcher = new AntPathMatcher();
+
+  @Override
+  protected boolean shouldNotFilter(HttpServletRequest request) {
+    return request.getRequestURI().equals(LOGIN_URL)
+        || (request.getHeader("Authorization") == null
+        && EXCEPT_FILTER_URLS.stream().anyMatch(pattern -> antPathMatcher.match(pattern, request.getRequestURI())));
+  }
+
+  @Override
+  protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+      throws ServletException, IOException {
+    try {
+      String accessToken = jwtService.extractAccessToken(request);
+      jwtService.validateToken(accessToken);
+      SecurityUserDetails principal = jwtService.getSecurityUserDetails(accessToken);
+      setAuthentication(principal, accessToken);
+    } catch (Exception e) {
+      request.setAttribute("exception", e);
+    }
+    filterChain.doFilter(request, response);
+  }
+
+  private void setAuthentication(UserDetails principal, String accessToken) {
+    SecurityContextHolder.getContext().setAuthentication(
+        new UsernamePasswordAuthenticationToken(principal, accessToken, principal.getAuthorities())
+    );
+  }
+}

--- a/src/main/java/com/kh/bookfinder/auth/jwt/handler/JwtForbiddenHandler.java
+++ b/src/main/java/com/kh/bookfinder/auth/jwt/handler/JwtForbiddenHandler.java
@@ -1,0 +1,35 @@
+package com.kh.bookfinder.auth.jwt.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kh.bookfinder.global.constants.Message;
+import com.kh.bookfinder.global.dto.ErrorResponseBody;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtForbiddenHandler implements AccessDeniedHandler {
+
+  private static final String SIGNUP_URLS = "/api/v1/signup";
+
+  @Override
+  public void handle(HttpServletRequest request, HttpServletResponse response,
+      AccessDeniedException accessDeniedException) throws IOException {
+    response.setContentType("application/json;charset=UTF-8");
+    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+
+    String url = request.getRequestURI();
+    if (url.startsWith(SIGNUP_URLS)) {
+      ErrorResponseBody errorResponseBody = ErrorResponseBody.builder()
+          .message(Message.FORBIDDEN)
+          .detail(Message.ALREADY_LOGIN)
+          .build();
+      new ObjectMapper().writeValue(response.getWriter(), errorResponseBody);
+    } else {
+      response.getWriter().write(accessDeniedException.getLocalizedMessage());
+    }
+  }
+}

--- a/src/main/java/com/kh/bookfinder/auth/jwt/handler/JwtUnauthorizedHandler.java
+++ b/src/main/java/com/kh/bookfinder/auth/jwt/handler/JwtUnauthorizedHandler.java
@@ -1,0 +1,31 @@
+package com.kh.bookfinder.auth.jwt.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kh.bookfinder.global.constants.Message;
+import com.kh.bookfinder.global.dto.ErrorResponseBody;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JwtUnauthorizedHandler implements AuthenticationEntryPoint {
+
+
+  @Override
+  public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException)
+      throws IOException {
+    response.setContentType("application/json;charset=UTF-8");
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    Exception jwtException = (Exception) request.getAttribute("exception");
+
+    ErrorResponseBody errorResponseBody = ErrorResponseBody.builder()
+        .message(Message.UNAUTHORIZED)
+        .detail(jwtException.getLocalizedMessage())
+        .build();
+
+    new ObjectMapper().writeValue(response.getWriter(), errorResponseBody);
+  }
+}

--- a/src/main/java/com/kh/bookfinder/auth/jwt/service/JwtService.java
+++ b/src/main/java/com/kh/bookfinder/auth/jwt/service/JwtService.java
@@ -1,9 +1,19 @@
 package com.kh.bookfinder.auth.jwt.service;
 
 import com.kh.bookfinder.auth.login.dto.SecurityUserDetails;
+import com.kh.bookfinder.global.constants.Message;
+import com.kh.bookfinder.user.entity.User;
+import com.kh.bookfinder.user.repository.UserRepository;
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
 import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SecurityException;
+import jakarta.servlet.http.HttpServletRequest;
 import java.util.Date;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -12,19 +22,24 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 @Service
 @Slf4j
 @RequiredArgsConstructor
 public class JwtService {
 
-  public static final String CLAIM_AUTHORITIES = "auth";
   private static final String ACCESS_TOKEN_SUBJECT = "AccessToken";
   private static final String CLAIM_EMAIL = "email";
+  public static final String CLAIM_AUTHORITIES = "auth";
+  private static final String BEARER = "Bearer ";
   @Value("${jwt.secretKey}")
   private String secretKey;
   @Value("${jwt.access.expiration}")
   private Long accessTokenExpiration;
+  private final UserRepository userRepository;
+  @Value("${jwt.access.header}")
+  private String accessHeader;
 
   public String createAccessToken(Authentication authentication) {
     SecurityUserDetails user = (SecurityUserDetails) authentication.getPrincipal();
@@ -41,5 +56,44 @@ public class JwtService {
         .expiration(new Date(new Date().getTime() + accessTokenExpiration))
         .signWith(Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey)))
         .compact();
+  }
+
+  public String extractAccessToken(HttpServletRequest request) {
+    String bearerToken = request.getHeader(accessHeader);
+    if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER)) {
+      return bearerToken.replace(BEARER, "");
+    }
+    return null;
+  }
+
+  public SecurityUserDetails getSecurityUserDetails(String accessToken) {
+    Claims claims = Jwts.parser()
+        .verifyWith(Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey)))
+        .build()
+        .parseSignedClaims(accessToken)
+        .getPayload();
+    User serviceUser = userRepository
+        .findByEmail(claims.get(CLAIM_EMAIL, String.class))
+        .orElseThrow(() -> new JwtException(Message.INVALID_ACCESS_TOKEN));
+    return new SecurityUserDetails(serviceUser);
+  }
+
+  public boolean validateToken(String token)
+      throws ExpiredJwtException, UnsupportedJwtException, IllegalArgumentException {
+    try {
+      Jwts.parser()
+          .verifyWith(Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey)))
+          .build()
+          .parseSignedClaims(token);
+      return true;
+    } catch (SecurityException | MalformedJwtException e) {
+      throw new JwtException(Message.INVALID_JWT_SIGNATURE);
+    } catch (UnsupportedJwtException e) {
+      throw new JwtException(Message.INVALID_ACCESS_TOKEN);
+    } catch (ExpiredJwtException e) {
+      throw new JwtException(Message.EXPIRED_ACCESS_TOKEN);
+    } catch (IllegalArgumentException e) {
+      throw new JwtException(Message.NOT_LOGIN);
+    }
   }
 }

--- a/src/main/java/com/kh/bookfinder/auth/login/filter/JsonLoginFilter.java
+++ b/src/main/java/com/kh/bookfinder/auth/login/filter/JsonLoginFilter.java
@@ -8,10 +8,10 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.ConstraintViolation;
 import jakarta.validation.Validator;
 import java.io.IOException;
-import java.util.InvalidPropertiesFormatException;
 import java.util.Map;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.springframework.security.authentication.AuthenticationServiceException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.AuthenticationException;
@@ -39,7 +39,7 @@ public class JsonLoginFilter extends AbstractAuthenticationProcessingFilter {
   public Authentication attemptAuthentication(HttpServletRequest request, HttpServletResponse response)
       throws AuthenticationException, IOException {
     if (request.getContentType() == null || !request.getContentType().equals(CONTENT_TYPE)) {
-      throw new RuntimeException(Message.INVALID_CONTENT_TYPE);
+      throw new AuthenticationServiceException(Message.INVALID_CONTENT_TYPE);
     }
     LoginDto loginDto = parseDto(request);
     return getAuthentication(loginDto);
@@ -58,7 +58,7 @@ public class JsonLoginFilter extends AbstractAuthenticationProcessingFilter {
       Map<String, String> errorMap = violations
           .stream()
           .collect(Collectors.toMap(k -> k.getPropertyPath().toString(), ConstraintViolation::getMessage));
-      throw new InvalidPropertiesFormatException(objectMapper.writeValueAsString(errorMap));
+      throw new AuthenticationServiceException(objectMapper.writeValueAsString(errorMap));
     }
     return loginDto;
   }

--- a/src/main/java/com/kh/bookfinder/auth/login/filter/JsonLoginFilter.java
+++ b/src/main/java/com/kh/bookfinder/auth/login/filter/JsonLoginFilter.java
@@ -41,8 +41,15 @@ public class JsonLoginFilter extends AbstractAuthenticationProcessingFilter {
     if (request.getContentType() == null || !request.getContentType().equals(CONTENT_TYPE)) {
       throw new AuthenticationServiceException(Message.INVALID_CONTENT_TYPE);
     }
+    if (existsAuthorization(request)) {
+      throw new AuthenticationServiceException(Message.INVALID_LOGIN_WITH_AUTHORIZATION);
+    }
     LoginDto loginDto = parseDto(request);
     return getAuthentication(loginDto);
+  }
+
+  private boolean existsAuthorization(HttpServletRequest request) {
+    return request.getHeader("Authorization") != null;
   }
 
   private Authentication getAuthentication(LoginDto loginDto) {

--- a/src/main/java/com/kh/bookfinder/auth/login/handler/JsonLoginFailureHandler.java
+++ b/src/main/java/com/kh/bookfinder/auth/login/handler/JsonLoginFailureHandler.java
@@ -24,7 +24,7 @@ public class JsonLoginFailureHandler extends SimpleUrlAuthenticationFailureHandl
     } else if (isDtoException(exception)) {
       sendBadRequest(response, exception);
     } else {
-      sendUnauthorized(response, exception);
+      sendUnauthorized(response);
     }
   }
 
@@ -38,16 +38,15 @@ public class JsonLoginFailureHandler extends SimpleUrlAuthenticationFailureHandl
     new ObjectMapper().writeValue(response.getWriter(), responseBody);
   }
 
-  private void sendUnauthorized(HttpServletResponse response, AuthenticationException exception) throws IOException {
+  private void sendUnauthorized(HttpServletResponse response) throws IOException {
     response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
     ErrorResponseBody responseBody = ErrorResponseBody
         .builder()
         .message(Message.UNAUTHORIZED)
-        .detail(exception.getLocalizedMessage())
+        .detail(Message.FAIL_LOGIN)
         .build();
     new ObjectMapper().writeValue(response.getWriter(), responseBody);
   }
-
 
   @SuppressWarnings("unchecked")
   private void sendBadRequest(HttpServletResponse response, AuthenticationException exception)

--- a/src/main/java/com/kh/bookfinder/auth/login/handler/JsonLoginFailureHandler.java
+++ b/src/main/java/com/kh/bookfinder/auth/login/handler/JsonLoginFailureHandler.java
@@ -23,6 +23,8 @@ public class JsonLoginFailureHandler extends SimpleUrlAuthenticationFailureHandl
       sendUnsupportedMediaType(response, exception);
     } else if (isDtoException(exception)) {
       sendBadRequest(response, exception);
+    } else if (existsAuthorization(exception)) {
+      sendForbidden(response, exception);
     } else {
       sendUnauthorized(response);
     }
@@ -34,6 +36,16 @@ public class JsonLoginFailureHandler extends SimpleUrlAuthenticationFailureHandl
     ErrorResponseBody responseBody = ErrorResponseBody
         .builder()
         .message(exception.getLocalizedMessage())
+        .build();
+    new ObjectMapper().writeValue(response.getWriter(), responseBody);
+  }
+
+  private void sendForbidden(HttpServletResponse response, AuthenticationException exception) throws IOException {
+    response.setStatus(HttpServletResponse.SC_FORBIDDEN);
+    ErrorResponseBody responseBody = ErrorResponseBody
+        .builder()
+        .message(Message.FORBIDDEN)
+        .detail(exception.getLocalizedMessage())
         .build();
     new ObjectMapper().writeValue(response.getWriter(), responseBody);
   }
@@ -68,5 +80,9 @@ public class JsonLoginFailureHandler extends SimpleUrlAuthenticationFailureHandl
   private boolean isDtoException(AuthenticationException exception) {
     String message = exception.getLocalizedMessage();
     return message.contains(DTO_EMAIL) || message.contains(DTO_PASSWORD);
+  }
+
+  private boolean existsAuthorization(AuthenticationException exception) {
+    return exception.getMessage().contains(Message.INVALID_LOGIN_WITH_AUTHORIZATION);
   }
 }

--- a/src/main/java/com/kh/bookfinder/global/constants/Message.java
+++ b/src/main/java/com/kh/bookfinder/global/constants/Message.java
@@ -11,6 +11,7 @@ public interface Message {
   String NOT_FOUND = "요청하신 정보를 찾을 수 없습니다.";
   String UNAUTHORIZED = "인증 정보가 유효하지 않습니다.";
   String INVALID_CONTENT_TYPE = "유효하지 않은 Content-Type 입니다.";
+  String FORBIDDEN = "잘못된 권한입니다.";
 
   String VALID_EMAIL = "가입이 가능한 이메일입니다.\n사용하시겠습니까?";
   String INVALID_EMAIL = "유효하지 않은 이메일 형식입니다.";
@@ -27,6 +28,7 @@ public interface Message {
   String EXPIRED_AUTH_CODE = "인증 코드가 만료되었습니다.";
   String INVALID_SIGNING_TOKEN = "유효하지 않은 토큰입니다.";
   String FAIL_LOGIN = "이메일 또는 비밀번호가 올바르지 않습니다.";
+  String INVALID_LOGIN_WITH_AUTHORIZATION = "헤더에 Authorization이 있어 로그인 요청을 할 수 없습니다.";
 
 
   String INVALID_ISBN_DIGITS = "ISBN 번호는 13자리의 숫자만 입력 가능합니다.";

--- a/src/main/java/com/kh/bookfinder/global/constants/Message.java
+++ b/src/main/java/com/kh/bookfinder/global/constants/Message.java
@@ -29,7 +29,12 @@ public interface Message {
   String INVALID_SIGNING_TOKEN = "유효하지 않은 토큰입니다.";
   String FAIL_LOGIN = "이메일 또는 비밀번호가 올바르지 않습니다.";
   String INVALID_LOGIN_WITH_AUTHORIZATION = "헤더에 Authorization이 있어 로그인 요청을 할 수 없습니다.";
+  String ALREADY_LOGIN = "이미 로그인 되어 있습니다.";
+  String NOT_LOGIN = "회원 정보가 없습니다. 로그인 후 이용해주세요";
 
+  String INVALID_JWT_SIGNATURE = "잘못된 JWT 서명입니다.";
+  String INVALID_ACCESS_TOKEN = "유효하지 않은 JWT 토큰입니다.";
+  String EXPIRED_ACCESS_TOKEN = "만료된 JWT 토큰입니다.";
 
   String INVALID_ISBN_DIGITS = "ISBN 번호는 13자리의 숫자만 입력 가능합니다.";
   String UNSAVED_ISBN = "유효하지 않은 ISBN 번호 입니다.";

--- a/src/test/java/com/kh/bookfinder/auth/api/LoginApiTest.java
+++ b/src/test/java/com/kh/bookfinder/auth/api/LoginApiTest.java
@@ -49,10 +49,10 @@ public class LoginApiTest {
         .build();
   }
 
-  private ResultActions callLoginApi(LoginDto invalidLoginDto) throws Exception {
+  private ResultActions callLoginApi(LoginDto loginDto) throws Exception {
     return mockMvc.perform(MockMvcRequestBuilders
         .post("/api/v1/login")
-        .content(objectMapper.writeValueAsString(invalidLoginDto))
+        .content(objectMapper.writeValueAsString(loginDto))
         .contentType(MediaType.APPLICATION_JSON));
   }
 
@@ -155,5 +155,25 @@ public class LoginApiTest {
     // And: Response Body로 message와 details가 반환된다.
     resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.message", is(Message.UNAUTHORIZED)));
     resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.detail", is(Message.FAIL_LOGIN)));
+  }
+
+  @Test
+  @DisplayName("Header에 Authorization을 포함한 경우")
+  public void loginFailOnExistsAuthorizationInHeaderTest() throws Exception {
+    // Given: 로그인 정보가 주어진다.
+    LoginDto loginDto = getBaseLoginDto();
+
+    // When: Header에 "Authorization"을 추가하여 Login API를 호출한다.
+    ResultActions resultActions = mockMvc.perform(MockMvcRequestBuilders
+        .post("/api/v1/login")
+        .content(objectMapper.writeValueAsString(loginDto))
+        .contentType(MediaType.APPLICATION_JSON)
+        .header("Authorization", "testAccessToken"));
+
+    // Then: Status는 403 Forbidden이다.
+    resultActions.andExpect(MockMvcResultMatchers.status().isForbidden());
+    // And: Response Body로 message와 details가 반환된다.
+    resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.message", is(Message.FORBIDDEN)));
+    resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.detail", is(Message.INVALID_LOGIN_WITH_AUTHORIZATION)));
   }
 }

--- a/src/test/java/com/kh/bookfinder/auth/helper/MockToken.java
+++ b/src/test/java/com/kh/bookfinder/auth/helper/MockToken.java
@@ -1,0 +1,6 @@
+package com.kh.bookfinder.auth.helper;
+
+public interface MockToken {
+
+  String mockAccessToken = "Bearer eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJBY2Nlc3NUb2tlbiIsImVtYWlsIjoiamluaG80NzQ0QG5hdmVyLmNvbSIsImF1dGgiOiJST0xFX0FETUlOIiwiZXhwIjoxNzE2NTQ5NzI2fQ.Ys_2wvd-jgnxs648N_mBSEji-QAF0WCUQPk_aZ17fC-99kisHa7hBZL1WHLr3O-u11TAfDhtFJ8nwlOm2XNU1Q";
+}

--- a/src/test/java/com/kh/bookfinder/auth/login/LoginFilterTest.java
+++ b/src/test/java/com/kh/bookfinder/auth/login/LoginFilterTest.java
@@ -1,13 +1,14 @@
-package com.kh.bookfinder.auth.api;
+package com.kh.bookfinder.auth.login;
 
 import static org.hamcrest.core.Is.is;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.kh.bookfinder.auth.login.dto.LoginDto;
 import com.kh.bookfinder.global.constants.Message;
 import com.kh.bookfinder.user.entity.User;
-import com.kh.bookfinder.user.entity.UserRole;
+import com.kh.bookfinder.user.helper.MockUser;
 import com.kh.bookfinder.user.repository.UserRepository;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
@@ -19,7 +20,6 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -32,7 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 @ActiveProfiles("test")
-public class LoginApiTest {
+public class LoginFilterTest {
 
   @Autowired
   private MockMvc mockMvc;
@@ -62,17 +62,11 @@ public class LoginApiTest {
     // Given: 로그인 정보가 주어진다.
     LoginDto loginDto = getBaseLoginDto();
     // And: Repository가 Mock User객체를 리턴하도록 모킹한다.
-    User mockUser = User.builder()
-        .id(1L)
-        .email("jinho4744@naver.com")
-        .password(new BCryptPasswordEncoder().encode("test_password_123"))
-        .nickname("고소하게")
-        .role(UserRole.ROLE_ADMIN)
-        .build();
+    User mockUser = MockUser.getMockUser();
     when(userRepository.findByEmail(loginDto.getEmail())).thenReturn(Optional.of(mockUser));
 
     // When: Login API를 호출한다.
-    ResultActions resultActions = callLoginApi(loginDto);
+    ResultActions resultActions = callLoginApi(loginDto).andDo(print());
 
     // Then: Status는 200 Ok이다.
     resultActions.andExpect(MockMvcResultMatchers.status().isOk());
@@ -138,13 +132,7 @@ public class LoginApiTest {
     LoginDto loginDto = getBaseLoginDto();
     loginDto.setPassword("test_password_1");
     // And: Repository가 Mock User객체를 리턴하도록 모킹한다.
-    User mockUser = User.builder()
-        .id(1L)
-        .email("jinho4744@naver.com")
-        .password(new BCryptPasswordEncoder().encode("test_password_123"))
-        .nickname("고소하게")
-        .role(UserRole.ROLE_ADMIN)
-        .build();
+    User mockUser = MockUser.getMockUser();
     when(userRepository.findByEmail(loginDto.getEmail())).thenReturn(Optional.of(mockUser));
 
     // When: Login API를 호출한다.

--- a/src/test/java/com/kh/bookfinder/book_trade/api/ListBookTradeApiTest.java
+++ b/src/test/java/com/kh/bookfinder/book_trade/api/ListBookTradeApiTest.java
@@ -3,16 +3,21 @@ package com.kh.bookfinder.book_trade.api;
 
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kh.bookfinder.auth.helper.MockToken;
 import com.kh.bookfinder.book_trade.dto.BookTradeListResponseDto;
 import com.kh.bookfinder.book_trade.entity.BookTrade;
 import com.kh.bookfinder.book_trade.entity.Status;
 import com.kh.bookfinder.book_trade.helper.MockBookTrade;
 import com.kh.bookfinder.book_trade.repository.BookTradeRepository;
 import com.kh.bookfinder.global.constants.Message;
+import com.kh.bookfinder.user.helper.MockUser;
+import com.kh.bookfinder.user.repository.UserRepository;
 import java.util.ArrayList;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -44,17 +49,23 @@ public class ListBookTradeApiTest {
   private MockMvc mockMvc;
   @MockBean
   private BookTradeRepository bookTradeRepository;
+  @MockBean
+  private UserRepository userRepository;
 
   @Test
   @DisplayName("DB에 저장된 BookTrade 튜플이 없는 경우")
   public void listBookTradeSuccessOnEmptyBookTradeList() throws Exception {
     // Given: 유효한 Borough ID가 주어진다
     int boroughId = 1;
+    // And: UserRepository를 Mocking한다.
+    when(userRepository.findByEmail(any()))
+        .thenReturn(Optional.of(MockUser.getMockUser()));
 
     // When: List BookTrade API를 호출한다.
     ResultActions resultActions = mockMvc
         .perform(MockMvcRequestBuilders
-            .get("/api/v1/trades/list/{boroughId}", boroughId));
+            .get("/api/v1/trades/list/{boroughId}", boroughId)
+            .header("Authorization", MockToken.mockAccessToken));
     // Then: Status는 200이다.
     resultActions.andExpect(MockMvcResultMatchers.status().isOk());
     // And: Response Body로 BookTrade List를 반환한다. (Empty)
@@ -65,16 +76,20 @@ public class ListBookTradeApiTest {
   @DisplayName("DB에 BookTrade 튜플이 있는 경우")
   public void listBookTradeSuccessOnExistBookTradeList() throws Exception {
     // Given: 유효한 Borough ID가 주어진다
-    // And: Mock BookTrade List가 주어진다.
     Long boroughId = 1L;
+    // And: Mock BookTrade List가 주어진다.
     ArrayList<BookTrade> mockBookTrades = MockBookTrade.getMockBookTradeList(10);
     when(this.bookTradeRepository.findByBoroughIdAndDeleteYn(boroughId, Status.N))
         .thenReturn(mockBookTrades);
+    // And: UserRepository를 Mocking 한다.
+    when(this.userRepository.findByEmail(any()))
+        .thenReturn(Optional.of(MockUser.getMockUser()));
 
     // When: List BookTrade API를 호출한다.
     ResultActions resultActions = mockMvc
         .perform(MockMvcRequestBuilders
-            .get("/api/v1/trades/list/{boroughId}", boroughId));
+            .get("/api/v1/trades/list/{boroughId}", boroughId)
+            .header("Authorization", MockToken.mockAccessToken));
 
     // Then: Status는 200 Ok 이다.
     resultActions.andExpect(MockMvcResultMatchers.status().isOk());
@@ -95,16 +110,42 @@ public class ListBookTradeApiTest {
   public void listBookTradeFailOnInvalidBoroughId() throws Exception {
     // Given: 유효하지 않은 Borough ID가 주어진다
     int invalidBoroughId = 28;
+    // And: UserRepository를 Mocking 한다.
+    when(this.userRepository.findByEmail(any()))
+        .thenReturn(Optional.of(MockUser.getMockUser()));
 
     // When: List BookTrade API를 호출한다.
     ResultActions resultActions = mockMvc
         .perform(MockMvcRequestBuilders
-            .get("/api/v1/trades/list/{boroughId}", invalidBoroughId));
+            .get("/api/v1/trades/list/{boroughId}", invalidBoroughId)
+            .header("Authorization", MockToken.mockAccessToken));
 
     // Then: Status는 400 Bad Request 이다.
     resultActions.andExpect(MockMvcResultMatchers.status().isBadRequest());
     // And: Response Body로 message와 details를 반환한다.
     resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.message", is(Message.BAD_REQUEST)));
     resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.details.boroughId", is(Message.INVALID_BOROUGH)));
+  }
+
+  @Test
+  @DisplayName("Header에 Authorization이 없는 경우")
+  public void listBookTradeFailTestOnNotExistAuthorizationInHeader() throws Exception {
+    // Given: 유효한 Borough ID가 주어진다
+    Long boroughId = 1L;
+    // And: Mock BookTrade List가 주어진다.
+    ArrayList<BookTrade> mockBookTrades = MockBookTrade.getMockBookTradeList(10);
+    when(this.bookTradeRepository.findByBoroughIdAndDeleteYn(boroughId, Status.N))
+        .thenReturn(mockBookTrades);
+
+    // When: Header에 Authorization 없이 List BookTrade API를 호출한다.
+    ResultActions resultActions = mockMvc
+        .perform(MockMvcRequestBuilders
+            .get("/api/v1/trades/list/{boroughId}", boroughId));
+
+    // Then: Status는 401 Unauthorized 이다.
+    resultActions.andExpect(MockMvcResultMatchers.status().isUnauthorized());
+    // And: Response Body로 message와 details를 반환한다.
+    resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.message", is(Message.UNAUTHORIZED)));
+    resultActions.andExpect(MockMvcResultMatchers.jsonPath("$.detail", is(Message.NOT_LOGIN)));
   }
 }

--- a/src/test/java/com/kh/bookfinder/user/helper/MockUser.java
+++ b/src/test/java/com/kh/bookfinder/user/helper/MockUser.java
@@ -1,0 +1,18 @@
+package com.kh.bookfinder.user.helper;
+
+import com.kh.bookfinder.user.entity.User;
+import com.kh.bookfinder.user.entity.UserRole;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+public class MockUser {
+
+  public static User getMockUser() {
+    return User.builder()
+        .id(1L)
+        .email("jinho4744@naver.com")
+        .password(new BCryptPasswordEncoder().encode("test_password_123"))
+        .nickname("고소하게")
+        .role(UserRole.ROLE_ADMIN)
+        .build();
+  }
+}

--- a/src/test/resources/oneUserInsert.sql
+++ b/src/test/resources/oneUserInsert.sql
@@ -1,3 +1,0 @@
-insert into user(create_date, user_id, address, email, nickname, password, phone, social_id, role)
-values (current_date, 1, "testAddress", "jinho@kh.kr", "nickname", "password", "01012345678", "testSocialId",
-        "ROLE_USER");


### PR DESCRIPTION
# 참고
#82 

# JWT
- 로그인 시 AccessToken 발급
- 해당 AccessToken을 Header의 Auhorization에 "Bearer {AccessToken}" 형식으로 담아 보내야 함

# 인증(로그인)
- Header에 Authorization이 "Bearer {AccessToken}" 형식으로 있을 때 인증 되어있는 상태라고 볼 수 있음
  - AccessToken에 따른 인증 실패
    - AccessToken의 형식 오류 or Jwt 서명 실패
    - 유효하지 않은 AccessToken
    - AccessToken의 유효기간 만료
      - 아직 Refresh Token이 없기 때문에 AccessToken의 유효기간이 만료되었다면 다시 로그인 해야함
- 인증이 필요한 API
  - 회원 간 도서 대출 관련 모든 API (+ 댓글 관련 API)
  - 도서 요청 (도서 추가 API)
  - 도서 Status 변경 API
- 인증이 없어야하는 API
  - 회원가입 관련 모든 API
  - 로그인 API
- 인증이 필요없는 API 
  - 도서 검색 (도서 List API)
  - 도서 상세 (도서 Read One API)

# 인가(권한)
- AccessToken을 추출하여 해당 Token의 권한을 확인할 수 있음
- 권한에 따라 이용 가능한 API 분류
  - ADMIN
    - 도서 Status 상태 변경 API (승인/거절 등)
  - USER
    - 회원 간 도서 대출 관련 모든 API (+ 댓글 관련 API)
  - Anonymous
    - 도서 검색 (도서 List API)
    - 도서 상세 (도서 Read One API)
  - 회원가입, 로그인의 경우 Anonymous 권한 즉, 인증이 없는 상태에서만 가능   