### PR TITLE
JH-98: 소셜 로그인 기능 추가

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,7 @@ application-db.yml
 application-test*.properties
 application-mail.yml
 application-jwt.yml
+application-oauth.yml
 
 
 ### STS ###

--- a/build.gradle
+++ b/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-mail'
     implementation 'org.springframework.security:spring-security-crypto'
     implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.springframework.security:spring-security-oauth2-client'
     compileOnly 'org.projectlombok:lombok'
     developmentOnly 'org.springframework.boot:spring-boot-devtools'
     runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/kh/bookfinder/auth/jwt/service/JwtService.java
+++ b/src/main/java/com/kh/bookfinder/auth/jwt/service/JwtService.java
@@ -58,6 +58,16 @@ public class JwtService {
         .compact();
   }
 
+  public String createAccessToken(String email, String authorities) {
+    return Jwts.builder()
+        .subject(ACCESS_TOKEN_SUBJECT)
+        .claim(CLAIM_EMAIL, email)
+        .claim(CLAIM_AUTHORITIES, authorities)
+        .expiration(new Date(new Date().getTime() + accessTokenExpiration))
+        .signWith(Keys.hmacShaKeyFor(Decoders.BASE64.decode(secretKey)))
+        .compact();
+  }
+
   public String extractAccessToken(HttpServletRequest request) {
     String bearerToken = request.getHeader(accessHeader);
     if (StringUtils.hasText(bearerToken) && bearerToken.startsWith(BEARER)) {

--- a/src/main/java/com/kh/bookfinder/auth/oauth2/controller/OAuth2Controller.java
+++ b/src/main/java/com/kh/bookfinder/auth/oauth2/controller/OAuth2Controller.java
@@ -1,5 +1,6 @@
 package com.kh.bookfinder.auth.oauth2.controller;
 
+import com.kh.bookfinder.auth.jwt.dto.AccessTokenDto;
 import com.kh.bookfinder.auth.login.dto.SecurityUserDetails;
 import com.kh.bookfinder.auth.oauth2.dto.OAuth2SignUpDto;
 import com.kh.bookfinder.global.constants.Message;
@@ -10,6 +11,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.CookieValue;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -32,6 +35,15 @@ public class OAuth2Controller {
     return ResponseEntity
         .status(HttpStatus.CREATED)
         .body(Map.of("message", Message.SIGNUP_SUCCESS));
+  }
+
+  @GetMapping(value = "/accessToken", produces = "application/json;charset=UTF-8")
+  public ResponseEntity<AccessTokenDto> responseAccessTokenForOAuth2Login(
+      @CookieValue(name = "accessToken") String accessToken) {
+
+    return ResponseEntity
+        .ok()
+        .body(AccessTokenDto.builder().accessToken(accessToken).build());
   }
 
 }

--- a/src/main/java/com/kh/bookfinder/auth/oauth2/controller/OAuth2Controller.java
+++ b/src/main/java/com/kh/bookfinder/auth/oauth2/controller/OAuth2Controller.java
@@ -1,0 +1,37 @@
+package com.kh.bookfinder.auth.oauth2.controller;
+
+import com.kh.bookfinder.auth.login.dto.SecurityUserDetails;
+import com.kh.bookfinder.auth.oauth2.dto.OAuth2SignUpDto;
+import com.kh.bookfinder.global.constants.Message;
+import com.kh.bookfinder.user.service.UserService;
+import jakarta.validation.Valid;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/v1/oauth2")
+public class OAuth2Controller {
+
+  private final UserService userService;
+
+  @PostMapping(value = "/signup", produces = "application/json;charset=UTF-8")
+  public ResponseEntity<Map<String, String>> oAuthSignUp(@RequestBody @Valid OAuth2SignUpDto signUpDto) {
+    SecurityUserDetails securityUserDetails =
+        (SecurityUserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+
+    userService.updateSocialGuestToUser(securityUserDetails, signUpDto);
+
+    return ResponseEntity
+        .status(HttpStatus.CREATED)
+        .body(Map.of("message", Message.SIGNUP_SUCCESS));
+  }
+
+}

--- a/src/main/java/com/kh/bookfinder/auth/oauth2/dto/CustomOAuth2User.java
+++ b/src/main/java/com/kh/bookfinder/auth/oauth2/dto/CustomOAuth2User.java
@@ -1,0 +1,23 @@
+package com.kh.bookfinder.auth.oauth2.dto;
+
+import com.kh.bookfinder.user.entity.UserRole;
+import java.util.Collection;
+import java.util.Map;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+
+@Getter
+public class CustomOAuth2User extends DefaultOAuth2User {
+
+  private String email;
+  private UserRole role;
+
+  public CustomOAuth2User(Collection<? extends GrantedAuthority> authorities,
+      Map<String, Object> attributes, String nameAttributeKey,
+      String email, UserRole role) {
+    super(authorities, attributes, nameAttributeKey);
+    this.email = email;
+    this.role = role;
+  }
+}

--- a/src/main/java/com/kh/bookfinder/auth/oauth2/dto/GoogleOAuthAttributes.java
+++ b/src/main/java/com/kh/bookfinder/auth/oauth2/dto/GoogleOAuthAttributes.java
@@ -1,0 +1,20 @@
+package com.kh.bookfinder.auth.oauth2.dto;
+
+import java.util.Map;
+
+public class GoogleOAuthAttributes extends OAuthAttributes {
+
+  public GoogleOAuthAttributes(String nameAttributeKey, Map<String, Object> attributes) {
+    super(nameAttributeKey, attributes);
+  }
+
+  @Override
+  public String getId() {
+    return String.valueOf(attributes.get("sub"));
+  }
+
+  @Override
+  public String getProfileImageUrl() {
+    return String.valueOf(attributes.get("picture"));
+  }
+}

--- a/src/main/java/com/kh/bookfinder/auth/oauth2/dto/KakaoOAuthAttributes.java
+++ b/src/main/java/com/kh/bookfinder/auth/oauth2/dto/KakaoOAuthAttributes.java
@@ -1,0 +1,33 @@
+package com.kh.bookfinder.auth.oauth2.dto;
+
+import java.util.Map;
+
+public class KakaoOAuthAttributes extends OAuthAttributes {
+
+  public KakaoOAuthAttributes(String nameAttributeKey, Map<String, Object> attributes) {
+    super(nameAttributeKey, attributes);
+  }
+
+  @Override
+  public String getId() {
+    return String.valueOf(attributes.get("id"));
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public String getProfileImageUrl() {
+    Map<String, Object> account = (Map<String, Object>) attributes.get("kakao_account");
+
+    if (account == null) {
+      return null;
+    }
+
+    Map<String, Object> profile = (Map<String, Object>) account.get("profile");
+
+    if (profile == null) {
+      return null;
+    }
+
+    return (String) profile.get("thumbnail_image_url");
+  }
+}

--- a/src/main/java/com/kh/bookfinder/auth/oauth2/dto/OAuth2SignUpDto.java
+++ b/src/main/java/com/kh/bookfinder/auth/oauth2/dto/OAuth2SignUpDto.java
@@ -1,0 +1,24 @@
+package com.kh.bookfinder.auth.oauth2.dto;
+
+import com.kh.bookfinder.global.constants.Message;
+import com.kh.bookfinder.global.constants.Regexp;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class OAuth2SignUpDto {
+
+  @Pattern(regexp = Regexp.NICKNAME, message = Message.INVALID_NICKNAME)
+  private String nickname;
+  @NotNull(message = "올바른 주소를 입력하세요.")
+  private String address;
+  @Pattern(regexp = Regexp.PHONE, message = Message.INVALID_PHONE)
+  private String phone;
+}

--- a/src/main/java/com/kh/bookfinder/auth/oauth2/dto/OAuthAttributes.java
+++ b/src/main/java/com/kh/bookfinder/auth/oauth2/dto/OAuthAttributes.java
@@ -1,0 +1,53 @@
+package com.kh.bookfinder.auth.oauth2.dto;
+
+import com.kh.bookfinder.user.entity.User;
+import com.kh.bookfinder.user.entity.UserRole;
+import java.util.Map;
+import java.util.UUID;
+import lombok.Getter;
+
+@Getter
+public abstract class OAuthAttributes {
+
+  protected String nameAttributeKey;
+  protected Map<String, Object> attributes;
+
+  public OAuthAttributes(String nameAttributeKey, Map<String, Object> attributes) {
+    this.nameAttributeKey = nameAttributeKey;
+    this.attributes = attributes;
+  }
+
+  public static OAuthAttributes of(String socialType, String nameAttributeKey, Map<String, Object> attributes) {
+    if (socialType.equals("kakao")) {
+      return kakao(nameAttributeKey, attributes);
+    }
+    if (socialType.equals("google")) {
+      return google(nameAttributeKey, attributes);
+    }
+    return null;
+  }
+
+  private static OAuthAttributes kakao(String nameAttributeKey, Map<String, Object> attributes) {
+    return new KakaoOAuthAttributes(nameAttributeKey, attributes);
+  }
+
+  private static OAuthAttributes google(String nameAttributeKey, Map<String, Object> attributes) {
+    return new GoogleOAuthAttributes(nameAttributeKey, attributes);
+  }
+
+  public abstract String getId();
+
+  public abstract String getProfileImageUrl();
+
+  public User toEntity(String socialType, OAuthAttributes attributes) {
+    return User.builder()
+        .email(UUID.randomUUID() + "@" + socialType + "User.com")
+        .socialId(attributes.getId())
+        .password("")
+        .nickname(socialType + attributes.getId())
+        .role(UserRole.ROLE_SOCIAL_GUEST)
+        .build();
+  }
+
+
+}

--- a/src/main/java/com/kh/bookfinder/auth/oauth2/handler/OAuth2LoginFailureHandler.java
+++ b/src/main/java/com/kh/bookfinder/auth/oauth2/handler/OAuth2LoginFailureHandler.java
@@ -1,0 +1,28 @@
+package com.kh.bookfinder.auth.oauth2.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kh.bookfinder.global.constants.Message;
+import com.kh.bookfinder.global.dto.ErrorResponseBody;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OAuth2LoginFailureHandler implements AuthenticationFailureHandler {
+
+  @Override
+  public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+      AuthenticationException exception) throws IOException {
+    response.setContentType("application/json;charset=UTF-8");
+    response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+    ErrorResponseBody responseBody = ErrorResponseBody
+        .builder()
+        .message(Message.UNAUTHORIZED)
+        .detail(Message.FAIL_LOGIN)
+        .build();
+    new ObjectMapper().writeValue(response.getWriter(), responseBody);
+  }
+}

--- a/src/main/java/com/kh/bookfinder/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
+++ b/src/main/java/com/kh/bookfinder/auth/oauth2/handler/OAuth2LoginSuccessHandler.java
@@ -1,0 +1,40 @@
+package com.kh.bookfinder.auth.oauth2.handler;
+
+import com.kh.bookfinder.auth.jwt.service.JwtService;
+import com.kh.bookfinder.auth.oauth2.dto.CustomOAuth2User;
+import com.kh.bookfinder.user.entity.UserRole;
+import com.kh.bookfinder.user.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class OAuth2LoginSuccessHandler implements AuthenticationSuccessHandler {
+
+  private final JwtService jwtService;
+  private final UserRepository userRepository;
+
+  @Override
+  public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+      Authentication authentication) throws IOException {
+    CustomOAuth2User customOAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+    String accessToken = jwtService.createAccessToken(customOAuth2User.getEmail(), customOAuth2User.getRole().name());
+
+    if (customOAuth2User.getRole() == UserRole.ROLE_SOCIAL_GUEST) {
+      response.sendRedirect("http://localhost:3000/oauth2/sign-up?token=" + accessToken);
+    } else {
+      Cookie cookie = new Cookie("accessToken", accessToken);
+      cookie.setPath("/");
+      cookie.setMaxAge(30);
+      response.addCookie(cookie);
+
+      response.sendRedirect("http://localhost:3000/oauth2/login");
+    }
+  }
+}

--- a/src/main/java/com/kh/bookfinder/auth/oauth2/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/kh/bookfinder/auth/oauth2/service/CustomOAuth2UserService.java
@@ -1,0 +1,54 @@
+package com.kh.bookfinder.auth.oauth2.service;
+
+import com.kh.bookfinder.auth.oauth2.dto.CustomOAuth2User;
+import com.kh.bookfinder.auth.oauth2.dto.OAuthAttributes;
+import com.kh.bookfinder.user.entity.User;
+import com.kh.bookfinder.user.repository.UserRepository;
+import java.util.Collections;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+  private final UserRepository userRepository;
+
+  @Override
+  public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+    OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+    OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+    String registrationId = userRequest.getClientRegistration().getRegistrationId();
+    String socialType = registrationId.toLowerCase();
+    String userNameAttributeName = userRequest.getClientRegistration()
+        .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+    Map<String, Object> defaultOAuthAttributes = oAuth2User.getAttributes();
+
+    OAuthAttributes extractOAuthAttributes = OAuthAttributes
+        .of(socialType, userNameAttributeName, defaultOAuthAttributes);
+
+    assert extractOAuthAttributes != null;
+    User createdServiceUser = userRepository.findBySocialId(extractOAuthAttributes.getId())
+        .orElse(null);
+    if (createdServiceUser == null) {
+      createdServiceUser = extractOAuthAttributes.toEntity(socialType, extractOAuthAttributes);
+      userRepository.save(createdServiceUser);
+    }
+
+    return new CustomOAuth2User(
+        Collections.singleton(new SimpleGrantedAuthority(createdServiceUser.getRole().name())),
+        defaultOAuthAttributes,
+        extractOAuthAttributes.getNameAttributeKey(),
+        createdServiceUser.getEmail(),
+        createdServiceUser.getRole()
+    );
+  }
+}

--- a/src/main/java/com/kh/bookfinder/user/controller/SignUpController.java
+++ b/src/main/java/com/kh/bookfinder/user/controller/SignUpController.java
@@ -30,7 +30,7 @@ public class SignUpController {
 
   @PostMapping(value = "", produces = "application/json;charset=UTF-8")
   public ResponseEntity<Map<String, String>> signUp(@RequestBody @Valid SignUpDto signUpDto) {
-    userService.save(signUpDto);
+    userService.createNewUser(signUpDto);
 
     return ResponseEntity
         .status(HttpStatus.CREATED)

--- a/src/main/java/com/kh/bookfinder/user/repository/UserRepository.java
+++ b/src/main/java/com/kh/bookfinder/user/repository/UserRepository.java
@@ -11,4 +11,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
   Optional<User> findByEmail(String email);
 
   Optional<User> findByNickname(String nickname);
+
+  Optional<User> findBySocialId(String socialId);
 }

--- a/src/main/java/com/kh/bookfinder/user/service/UserService.java
+++ b/src/main/java/com/kh/bookfinder/user/service/UserService.java
@@ -1,15 +1,19 @@
 package com.kh.bookfinder.user.service;
 
+import com.kh.bookfinder.auth.login.dto.SecurityUserDetails;
+import com.kh.bookfinder.auth.oauth2.dto.OAuth2SignUpDto;
 import com.kh.bookfinder.global.constants.Message;
 import com.kh.bookfinder.global.exception.InvalidFieldException;
 import com.kh.bookfinder.user.dto.DuplicateCheckDto;
 import com.kh.bookfinder.user.dto.SignUpDto;
 import com.kh.bookfinder.user.entity.User;
+import com.kh.bookfinder.user.entity.UserRole;
 import com.kh.bookfinder.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.rest.webmvc.ResourceNotFoundException;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -18,7 +22,7 @@ public class UserService {
   private final UserRepository userRepository;
   private final PasswordEncoder passwordEncoder;
 
-  public void save(SignUpDto signUpDto) {
+  public void createNewUser(SignUpDto signUpDto) {
     if (!signUpDto.equalsPassword()) {
       throw new InvalidFieldException("password", Message.INVALID_PASSWORD_CONFIRM);
     }
@@ -56,5 +60,17 @@ public class UserService {
   public User findUser(Long userId) {
     return this.userRepository.findById(userId)
         .orElseThrow(() -> new ResourceNotFoundException(Message.NOT_FOUND_USER));
+  }
+
+  @Transactional
+  public void updateSocialGuestToUser(SecurityUserDetails securityUserDetails, OAuth2SignUpDto signUpDto) {
+    String email = securityUserDetails.getUsername();
+    User socialGuest = userRepository.findByEmail(email).orElseThrow(
+        () -> new ResourceNotFoundException(Message.NOT_FOUND_USER)
+    );
+    socialGuest.setNickname(signUpDto.getNickname());
+    socialGuest.setAddress(signUpDto.getAddress());
+    socialGuest.setPhone(signUpDto.getPhone());
+    socialGuest.setRole(UserRole.ROLE_USER);
   }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,2 @@
 spring.application.name=BookFinder
-spring.config.import=classpath:application-db.yml, application-mail.yml, application-jwt.yml
+spring.config.import=classpath:application-db.yml, application-mail.yml, application-jwt.yml, application-oauth.yml

--- a/src/test/java/com/kh/bookfinder/auth/login/JsonLoginFilterTest.java
+++ b/src/test/java/com/kh/bookfinder/auth/login/JsonLoginFilterTest.java
@@ -32,7 +32,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 @AutoConfigureTestDatabase(replace = Replace.NONE)
 @ActiveProfiles("test")
-public class LoginFilterTest {
+public class JsonLoginFilterTest {
 
   @Autowired
   private MockMvc mockMvc;


### PR DESCRIPTION
#98 

# OAuth2
- 라이브러리 추가 및 설정 파일 생성
  - 설정 파일은 '개발환경세팅-backend'에 올림

# Spring Security 설정
- OAuth2UserService를 구현하는 CustomOAuth2UserService 클래스와 Login Success, Failure Handler 추가
  - 소셜 로그인 시 설정 파일에 작성해둔 Redirect URI를 통해 Custom2UserService로 이동
  - Custom2UserService에서 설정 파일에 작성해둔 정보로 소셜 로그인 한 회원 정보를 가져옴
      - 회원 정보가 DB에 없다면 ROLE_SOCIAL_GUEST로 데이터베이스에 임시 저장
  - SuccessHandler로 이동하여 해당 회원이 ROLE_SOCIAL_GUEST라면 추가정보 입력하는 페이지로 리다이렉트
  - SuccessHandler로 이동하여 해당 회원이 ROLE_USER라면 AccessToken을 요청하는 페이지로 리다이렉트

# 추가 정보 입력 API
- 추가정보 입력하는 페이지로 리다이렉트 되어 관련 정보 입력후 API 요청
  - 해당 유저를 DB에서 가져와 ROLE_SOCIAL_GUEST를 ROLE_USER로 바꿔주고 입력한 추가 정보로 바꿔줌
  - 이후 회원가입 API와 동일 #31 

# 토큰 발급 API
- 추가 정보 입력하여 가입 완료된 소셜 로그인 회원이 로그인 하면 로그인 대기화면으로 리다이렉트
  - 리다이렉트 전에 쿠키에 AccessToken을 담아 보냄
    - 리다이렉트 때문에 Header에 AccessToken을 담아도 없어지고 + 세션 설정은 Stateless로 했기 때문에 쿠키 사용
  - 리다이렉트 된 로그인 대기화면에서 AccessToken을 요청하는 API 호출
  - Controller에서 쿠키에 있는 AccessToken을 ResponseEntity에 담아서 보내고 쿠키는 삭제

# Issue
- 프론트와 마찬가지로 Happy Path에 대해서만 간단하게 테스트해보고 PR 올렸습니다.