### PR TITLE
JH-114: Create BookTrade API 테스트코드 추가

### DIFF
--- a/src/main/java/com/kh/bookfinder/book_trade/controller/BookTradeController.java
+++ b/src/main/java/com/kh/bookfinder/book_trade/controller/BookTradeController.java
@@ -69,11 +69,11 @@ public class BookTradeController {
 
   @PostMapping
   public ResponseEntity<BookTrade> createBookTrade(@RequestBody @Valid BookTradeRequestDto tradeDto) {
-    Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-    SecurityUserDetails principal = (SecurityUserDetails) authentication.getPrincipal();
-    String email = principal.getUsername();
+    SecurityUserDetails principal = (SecurityUserDetails)
+        SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+    User serviceUser = principal.getServiceUser();
 
-    bookTradeService.saveBookTrade(email, tradeDto);
+    bookTradeService.saveBookTrade(serviceUser, tradeDto);
     return ResponseEntity.status(HttpStatus.CREATED).build();
   }
 

--- a/src/main/java/com/kh/bookfinder/book_trade/dto/BookTradeRequestDto.java
+++ b/src/main/java/com/kh/bookfinder/book_trade/dto/BookTradeRequestDto.java
@@ -4,38 +4,40 @@ import com.kh.bookfinder.book.entity.Book;
 import com.kh.bookfinder.book_trade.entity.BookTrade;
 import com.kh.bookfinder.book_trade.entity.TradeType;
 import com.kh.bookfinder.global.constants.Message;
-import jakarta.validation.constraints.Max;
-import jakarta.validation.constraints.Min;
+import com.kh.bookfinder.user.entity.User;
 import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.util.Date;
+import lombok.Builder;
 import lombok.Data;
+import org.hibernate.validator.constraints.Range;
 
 @Data
+@Builder
 public class BookTradeRequestDto {
 
-  @Min(value = 1000000000000L, message = Message.INVALID_ISBN_DIGITS)
-  @Max(value = 9999999999999L, message = Message.INVALID_ISBN_DIGITS)
+  @Range(min = 1000000000000L, max = 9999999999999L, message = Message.INVALID_ISBN_DIGITS)
   private Long isbn;
   private TradeType tradeType;
-  @NotNull(message = Message.COST_REQUIRED)
-  @Min(value = 0, message = Message.INVALID_COST)
-  @Max(value = 100000, message = Message.INVALID_COST)
+  @NotNull(message = Message.INVALID_COST)
+  @Range(max = 100000L, message = Message.INVALID_COST)
   private Integer rentalCost;
   private Date limitedDate;
   private String content;
   private BigDecimal latitude;
   private BigDecimal longitude;
 
-  public BookTrade toEntity(Book book) {
+  public BookTrade toEntity(User user, Book book) {
     return BookTrade.builder()
-        .book(book)
         .tradeType(this.tradeType)
         .rentalCost(this.rentalCost)
         .limitedDate(this.limitedDate)
         .content(this.content)
         .latitude(this.latitude)
         .longitude(this.longitude)
+
+        .user(user)
+        .book(book)
         .build();
   }
 }

--- a/src/main/java/com/kh/bookfinder/book_trade/service/BookTradeService.java
+++ b/src/main/java/com/kh/bookfinder/book_trade/service/BookTradeService.java
@@ -72,11 +72,9 @@ public class BookTradeService {
   }
 
   @Transactional
-  public void saveBookTrade(String email, BookTradeRequestDto tradeDto) {
-    User user = userService.findUser(email);
+  public void saveBookTrade(User serviceUser, BookTradeRequestDto tradeDto) {
     Book book = bookService.findApprovedBook(tradeDto.getIsbn());
-    BookTrade bookTrade = tradeDto.toEntity(book);
-    bookTrade.setUser(user);
+    BookTrade bookTrade = tradeDto.toEntity(serviceUser, book);
     bookTradeRepository.save(bookTrade);
   }
 

--- a/src/main/java/com/kh/bookfinder/global/constants/Message.java
+++ b/src/main/java/com/kh/bookfinder/global/constants/Message.java
@@ -38,7 +38,6 @@ public interface Message {
   String INVALID_ISBN_DIGITS = "ISBN 번호는 13자리의 숫자만 입력 가능합니다.";
   String UNSAVED_ISBN = "유효하지 않은 ISBN 번호 입니다.";
   String INVALID_COST = "금액은 0부터 100000까지의 정수값만 입력 가능합니다.";
-  String COST_REQUIRED = "금액은 빈값일 수 없습니다.";
   String INVALID_BOROUGH = "지역 번호는 1부터 25까지의 숫자만 입력 가능합니다.";
   String NOT_FOUND_TRADE = "거래 번호를 찾을 수 없습니다.";
   String DELETED_TRADE = "삭제된 게시물 입니다.";

--- a/src/main/java/com/kh/bookfinder/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/kh/bookfinder/global/exception/GlobalExceptionHandler.java
@@ -14,6 +14,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.validation.FieldError;
@@ -32,6 +33,18 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     ErrorResponseBody errorResponseBody = ErrorResponseBody.builder()
         .message(BAD_REQUEST)
         .details(extractDetailsForField(ex))
+        .build();
+
+    return ResponseEntity.badRequest()
+        .body(errorResponseBody);
+  }
+
+  @Override
+  protected ResponseEntity<Object> handleHttpMessageNotReadable(HttpMessageNotReadableException ex, HttpHeaders headers,
+      HttpStatusCode status, WebRequest request) {
+    ErrorResponseBody errorResponseBody = ErrorResponseBody.builder()
+        .message(BAD_REQUEST)
+        .detail(ex.getLocalizedMessage())
         .build();
 
     return ResponseEntity.badRequest()

--- a/src/test/java/com/kh/bookfinder/book_trade/CreateBookTradeApiTest.java
+++ b/src/test/java/com/kh/bookfinder/book_trade/CreateBookTradeApiTest.java
@@ -1,0 +1,209 @@
+package com.kh.bookfinder.book_trade;
+
+import static com.kh.bookfinder.global.constants.HttpErrorMessage.BAD_REQUEST;
+import static com.kh.bookfinder.global.constants.HttpErrorMessage.NOT_FOUND;
+import static com.kh.bookfinder.global.constants.HttpErrorMessage.UNAUTHORIZED;
+import static org.hamcrest.core.Is.is;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.kh.bookfinder.auth.jwt.service.JwtService;
+import com.kh.bookfinder.book.entity.ApprovalStatus;
+import com.kh.bookfinder.book.entity.Book;
+import com.kh.bookfinder.book.repository.BookRepository;
+import com.kh.bookfinder.book_trade.dto.BookTradeRequestDto;
+import com.kh.bookfinder.book_trade.entity.BookTrade;
+import com.kh.bookfinder.book_trade.repository.BookTradeRepository;
+import com.kh.bookfinder.global.constants.Message;
+import com.kh.bookfinder.helper.MockBook;
+import com.kh.bookfinder.helper.MockBookTrade;
+import com.kh.bookfinder.helper.MockUser;
+import com.kh.bookfinder.helper.RequestDto;
+import com.kh.bookfinder.user.entity.User;
+import com.kh.bookfinder.user.entity.UserRole;
+import com.kh.bookfinder.user.repository.UserRepository;
+import io.jsonwebtoken.JwtException;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase.Replace;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.transaction.annotation.Transactional;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@Transactional
+@AutoConfigureTestDatabase(replace = Replace.NONE)
+@ActiveProfiles("test")
+@SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+public class CreateBookTradeApiTest {
+
+  private static final String VALID_ACCESS_TOKEN = "validAccessToken";
+  @Autowired
+  private MockMvc mockMvc;
+  @Autowired
+  private ObjectMapper objectMapper;
+  @MockBean
+  private JwtService jwtService;
+  @MockBean
+  private UserRepository userRepository;
+  @MockBean
+  private BookTradeRepository bookTradeRepository;
+  @MockBean
+  private BookRepository bookRepository;
+
+  private void mockJwtAuthenticationFilter(User mockUser) {
+    // JwtAuthenticationFilter Mocking
+    // extractAccessToken() -> "validAccessToken"
+    // validateToken() -> true
+    // extractEmail() -> mockUser's email;
+    when(jwtService.extractAccessToken(any())).thenReturn(VALID_ACCESS_TOKEN);
+    when(jwtService.validateToken(VALID_ACCESS_TOKEN)).thenReturn(true);
+    when(jwtService.extractEmail(VALID_ACCESS_TOKEN)).thenReturn(mockUser.getEmail());
+    // And: UserRepository가 mockUser를 반환
+    when(userRepository.findByEmail(mockUser.getEmail())).thenReturn(Optional.of(mockUser));
+  }
+
+  private ResultActions callApiWithAuthorization(BookTradeRequestDto requestDto) throws Exception {
+    String requestBody = objectMapper.writeValueAsString(requestDto);
+
+    return mockMvc.perform(
+        post("/api/v1/trades")
+            .header("Authorization", "Bearer " + VALID_ACCESS_TOKEN)
+            .content(requestBody)
+            .contentType("application/json")
+    );
+  }
+
+  @Test
+  @DisplayName("권한이 있고 유효한 BookTradeRequestDto가 주어졌을 때")
+  public void success_onValidBookTradeRequestDto_withAuthorization() throws Exception {
+    // Given: 권한이 "ROLE_USER"인 User가 주어진다.
+    User mockUser = MockUser.getMockUser();
+    mockUser.setRole(UserRole.ROLE_USER);
+    // And: ApprovalStatus가 "APPROVE"인 Book이 주어진다.
+    Book mockBook = MockBook.getMockBook();
+    mockBook.setApprovalStatus(ApprovalStatus.APPROVE);
+    // And: 유효한 BookTradeRequestDto가 주어진다.
+    BookTradeRequestDto requestDto = RequestDto.getBaseBookTradeRequestDto();
+    // And: mockBookTrade가 주어진다.
+    BookTrade mockBookTrade = MockBookTrade.buildOnRequest(requestDto);
+    mockBookTrade.setBook(mockBook);
+    mockBookTrade.setUser(mockUser);
+
+    // Mocking: JwtAuthenticationFilter Mocking
+    mockJwtAuthenticationFilter(mockUser);
+    // And: BookTradeRepository가 mockBookTrade를 반환
+    when(bookTradeRepository.save(any(BookTrade.class))).thenReturn(mockBookTrade);
+    // And: BookRepository가 mockBookTrade의 Book을 반환
+    when(bookRepository.findByIsbnAndApprovalStatus(requestDto.getIsbn(), ApprovalStatus.APPROVE))
+        .thenReturn(Optional.of(mockBookTrade.getBook()));
+
+    // When: Create BookTrade API를 호출한다.
+    ResultActions resultActions = callApiWithAuthorization(requestDto);
+
+    // Then: Status는 Created이다.
+    resultActions.andExpect(status().isCreated());
+  }
+
+  @Test
+  @DisplayName("유효하지 않은 Isbn이 주어졌을 때")
+  public void fail_onInvalidBookTradeRequestDto_WithIsbn() throws Exception {
+    // Given: 권한이 "ROLE_ADMIN"인 User가 주어진다.
+    User mockUser = MockUser.getMockUser();
+    mockUser.setRole(UserRole.ROLE_ADMIN);
+    // And: 유효하지 않은 BookTradeRequestDto가 주어진다.
+    BookTradeRequestDto invalidRequestDto = RequestDto.getBaseBookTradeRequestDto();
+    invalidRequestDto.setIsbn(1L);
+
+    // Mocking: JwtAuthenticationFilter Mocking
+    mockJwtAuthenticationFilter(mockUser);
+
+    // When: Create BookTrade API를 호출한다.
+    ResultActions resultActions = callApiWithAuthorization(invalidRequestDto);
+
+    // Then: Status는 Bad Request이다.
+    resultActions.andExpect(status().isBadRequest());
+    // And: Response Body로 message와 details를 반환한다.
+    resultActions.andExpect(jsonPath("$.message", is(BAD_REQUEST.getMessage())));
+    resultActions.andExpect(jsonPath("$.details.isbn", is(Message.INVALID_ISBN_DIGITS)));
+  }
+
+  @Test
+  @DisplayName("유효한 Isbn에 해당하는 Book이 없을 때")
+  public void fail_onNotExistBookInDB_WithIsbn() throws Exception {
+    // Given: 권한이 "ROLE_ADMIN"인 User가 주어진다.
+    User mockUser = MockUser.getMockUser();
+    mockUser.setRole(UserRole.ROLE_ADMIN);
+    // And: 유효한 BookTradeRequestDto가 주어진다.
+    BookTradeRequestDto validRequestDto = RequestDto.getBaseBookTradeRequestDto();
+
+    // Mocking: JwtAuthenticationFilter Mocking
+    mockJwtAuthenticationFilter(mockUser);
+
+    // When: Create BookTrade API를 호출한다.
+    ResultActions resultActions = callApiWithAuthorization(validRequestDto);
+
+    // Then: Status는 Not Found이다.
+    resultActions.andExpect(status().isNotFound());
+    // And: Response Body로 message와 detail을 반환한다.
+    resultActions.andExpect(jsonPath("$.message", is(NOT_FOUND.getMessage())));
+    resultActions.andExpect(jsonPath("$.detail", is(Message.NOT_FOUND_BOOK)));
+  }
+
+  @Test
+  @DisplayName("유효하지 않은 rentalCost가 주어졌을 때")
+  public void fail_onInvalidBookTradeRequestDto_WithRentalCost() throws Exception {
+    // Given: 권한이 "ROLE_ADMIN"인 User가 주어진다.
+    User mockUser = MockUser.getMockUser();
+    mockUser.setRole(UserRole.ROLE_ADMIN);
+    // And: 유효하지 않은 BookTradeRequestDto가 주어진다.
+    BookTradeRequestDto invalidRequestDto = RequestDto.getBaseBookTradeRequestDto();
+    invalidRequestDto.setRentalCost(null);
+
+    // Mocking: JwtAuthenticationFilter Mocking
+    mockJwtAuthenticationFilter(mockUser);
+
+    // When: Create BookTrade API를 호출한다.
+    ResultActions resultActions = callApiWithAuthorization(invalidRequestDto);
+
+    // Then: Status는 Bad Request이다.
+    resultActions.andExpect(status().isBadRequest());
+    // And: Response Body로 message와 detail을 반환한다.
+    resultActions.andExpect(jsonPath("$.message", is(BAD_REQUEST.getMessage())));
+    resultActions.andExpect(jsonPath("$.details.rentalCost", is(Message.INVALID_COST)));
+  }
+
+  @Test
+  @DisplayName("권한 없이 요청했을 때")
+  public void fail_onNoAuthorization() throws Exception {
+    // And: 유효한 BookTradeRequestDto가 주어진다.
+    BookTradeRequestDto invalidRequestDto = RequestDto.getBaseBookTradeRequestDto();
+
+    // Mocking: JwtService가 JwtException을 발생
+    when(jwtService.validateToken(any())).thenThrow(new JwtException(Message.NOT_LOGIN));
+
+    // When: 권한 없이 Create BookTrade API를 호출한다.
+    ResultActions resultActions = mockMvc.perform(post("/api/v1/trades")
+        .content(objectMapper.writeValueAsString(invalidRequestDto))
+        .contentType("application/json")
+    );
+
+    // Then: Status는 Unauthorized이다.
+    resultActions.andExpect(status().isUnauthorized());
+    // And: Response Body로 message와 detail을 반환한다.
+    resultActions.andExpect(jsonPath("$.message", is(UNAUTHORIZED.getMessage())));
+    resultActions.andExpect(jsonPath("$.detail", is(Message.NOT_LOGIN)));
+  }
+}

--- a/src/test/java/com/kh/bookfinder/book_trade/GetBookTradeOneApiTest.java
+++ b/src/test/java/com/kh/bookfinder/book_trade/GetBookTradeOneApiTest.java
@@ -1,4 +1,4 @@
-package com.kh.bookfinder.book_trade.api;
+package com.kh.bookfinder.book_trade;
 
 import static com.kh.bookfinder.global.constants.HttpErrorMessage.FORBIDDEN;
 import static com.kh.bookfinder.global.constants.HttpErrorMessage.NOT_FOUND;

--- a/src/test/java/com/kh/bookfinder/book_trade/ListBookTradeApiTest.java
+++ b/src/test/java/com/kh/bookfinder/book_trade/ListBookTradeApiTest.java
@@ -1,4 +1,4 @@
-package com.kh.bookfinder.book_trade.api;
+package com.kh.bookfinder.book_trade;
 
 
 import static com.kh.bookfinder.global.constants.HttpErrorMessage.BAD_REQUEST;

--- a/src/test/java/com/kh/bookfinder/helper/MockBook.java
+++ b/src/test/java/com/kh/bookfinder/helper/MockBook.java
@@ -1,5 +1,6 @@
 package com.kh.bookfinder.helper;
 
+import com.kh.bookfinder.book.entity.ApprovalStatus;
 import com.kh.bookfinder.book.entity.Book;
 
 public class MockBook {
@@ -13,6 +14,7 @@ public class MockBook {
         .publicationYear(2024)
         .description("test book description")
         .imageUrl("test book image url")
+        .approvalStatus(ApprovalStatus.APPROVE)
         .build();
   }
 }

--- a/src/test/java/com/kh/bookfinder/helper/MockBookTrade.java
+++ b/src/test/java/com/kh/bookfinder/helper/MockBookTrade.java
@@ -1,6 +1,7 @@
 package com.kh.bookfinder.helper;
 
 import com.kh.bookfinder.book.entity.Book;
+import com.kh.bookfinder.book_trade.dto.BookTradeRequestDto;
 import com.kh.bookfinder.book_trade.entity.BookTrade;
 import com.kh.bookfinder.book_trade.entity.Status;
 import com.kh.bookfinder.book_trade.entity.TradeType;
@@ -16,6 +17,17 @@ public class MockBookTrade {
 
   public static BookTrade getMockBookTrade() {
     return getMockBookTradeList(1).get(0);
+  }
+
+  public static BookTrade buildOnRequest(BookTradeRequestDto requestDto) {
+    return BookTrade.builder()
+        .tradeType(requestDto.getTradeType())
+        .rentalCost(requestDto.getRentalCost())
+        .limitedDate(requestDto.getLimitedDate())
+        .content(requestDto.getContent())
+        .latitude(requestDto.getLatitude())
+        .longitude(requestDto.getLongitude())
+        .build();
   }
 
   public static List<BookTrade> getMockBookTradeList(int count) {

--- a/src/test/java/com/kh/bookfinder/helper/RequestDto.java
+++ b/src/test/java/com/kh/bookfinder/helper/RequestDto.java
@@ -1,0 +1,22 @@
+package com.kh.bookfinder.helper;
+
+import com.kh.bookfinder.book_trade.dto.BookTradeRequestDto;
+import com.kh.bookfinder.book_trade.entity.TradeType;
+import java.math.BigDecimal;
+import java.sql.Date;
+import java.time.LocalDate;
+
+public class RequestDto {
+
+  public static BookTradeRequestDto getBaseBookTradeRequestDto() {
+    return BookTradeRequestDto.builder()
+        .isbn(9788960773424L)
+        .tradeType(TradeType.BORROW)
+        .rentalCost(1200)
+        .limitedDate(Date.valueOf(LocalDate.now().plusDays(7)))
+        .content("valid test content, 테스트 컨텐츠")
+        .latitude(BigDecimal.valueOf(12.3))
+        .longitude(BigDecimal.valueOf(23.4))
+        .build();
+  }
+}


### PR DESCRIPTION
# 리팩토링
- Min, Max 어노테이션 → Range 어노테이션 사용
- COST_REQUIRED → INVALID_COST로 통합
- SecurityUserDetails 인스턴스 내에 User정보도 담겨 있기 때문에 UserRepository 조회 중복 제거
